### PR TITLE
console now operates as a requests proxy

### DIFF
--- a/software/firmware/Makefile
+++ b/software/firmware/Makefile
@@ -4,8 +4,9 @@ include ../software.mk
 #additional compiler flags
 CFLAGS+=--specs=nano.specs -Wl,-Bstatic,-T,../template.lds,-Map,firmware.map,--strip-debug
 
-
-DEFINE+=-DLONGLONG
+#uncomment if you need to print floats and/or long long numbers
+#DEFINE+=-DFLOAT
+#DEFINE+=-DLONGLONG
 
 #SUBMODULES
 

--- a/software/pc-emul/Makefile
+++ b/software/pc-emul/Makefile
@@ -5,7 +5,8 @@ include ../software.mk
 CFLAGS=-Os -Wl,--strip-debug
 
 
-DEFINE+=-DLONGLONG -DPC
+#DEFINE+=-DLONGLONG 
+DEFINE+=-DPC
 
 #SUBMODULES
 


### PR DESCRIPTION
Sending and receiving files as a request from the firmware is now available (simulation not supported yet).
The console now operates as a proxy for requests from the firmware (easy to add new types of requests if needed).