### PR TITLE
Makefile for OpenRAM/OpenLane. OpenRAM make rule added

### DIFF
--- a/hardware/asic/README.md
+++ b/hardware/asic/README.md
@@ -242,6 +242,7 @@ git clone https://github.com/VLSIDA/OpenRAM
   ```bash
   export OPENRAM_HOME="$HOME/openram/compiler"
   export OPENRAM_TECH="$HOME/openram/technology"
+  export OPENRAM_CONFIG="$HOME/openram"
   ```
 3. Also add OPENRAM_HOME to your PYTHONPATH
 ```bash

--- a/hardware/asic/skywater/skywater130.mk
+++ b/hardware/asic/skywater/skywater130.mk
@@ -1,1 +1,7 @@
 #Makefile for OpenLane and OpenRAM started on 2/11/21
+SRAM:
+	python3 $(OPENRAM_HOME)/openram.py $(OPENRAM_CONFIG)/myconfig.py
+	
+.PHONY clean:
+	rm -rf __pycache__
+	rm -rf temp


### PR DESCRIPTION
This rule in the Makefile will run the OpenRAM (provided OpenRAM and all its dependencies are installed on that machine). 
Next step is to integrate it with asic.mk 
We can discuss this 
regards
Sharjeel