### PR TITLE
Changes made for OpenLane and now it is working

### DIFF
--- a/hardware/asic/README.md
+++ b/hardware/asic/README.md
@@ -32,7 +32,7 @@ In order to run OpenLane from Makefile provided in the hardware/asic/skywater fo
 ```bash
 export OPENLANE_HOME=<path to OpenLane root directory>
 ```
-Export the absolute path where the skywater-pdk and open-pdk will reside.
+Export the absolute path where the skywater-pdk and open-pdk will reside. Otherwise, they will reside inside the OpenLane root directory.
 ``` bash
 export PDK_ROOT=<absolute path to where skywater-pdk and open_pdks will reside>
 ```

--- a/hardware/asic/skywater/Makefile
+++ b/hardware/asic/skywater/Makefile
@@ -14,22 +14,25 @@ IMAGE_NAME ?= efabless/openlane:2021.07.29_04.49.46 #latest
 ifeq (0,$(shell docker -v 2>/dev/null | grep podman | wc -l))
    DOCKER_UID_OPTIONS = -u $(shell id -u $(USER)):$(shell id -g $(USER))
 endif
-DOK_CMD ?= "docker run -it --rm -v $(OPENLANE_HOME):/openLANE_flow -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT) $(DOCKER_UID_OPTIONS) $(IMAGE_NAME)"
+DOK_CMD ?= docker run --rm -v $(OPENLANE_HOME):/openLANE_flow -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT) $(DOCKER_UID_OPTIONS) $(IMAGE_NAME)
 
-.PHONY: all asic clean
+.PHONY: all asic clean_sram clean_asic
 
 all: sram asic
 
-#OpenRAM for SRAM generation
+#SRAM generation
 
 sram: asic_config.py
 	python3 $(OPENRAM_HOME)/openram.py asic_config.py
 	mv temp sram
-
-asic: $(VSRC) $(VHDR)
-	mkdir -p $(OPENLANE_DESIGNS)/iob-soc/src
-	cp $(VSRC) $(VHDR) $(OPENLANE_DESIGNS)
-	cd $(OPENLANE_HOME); $(DOK_CMD) sh -c  "./flow.tcl -design APU  --init_design_config -tag iob_soc -overwrite"
+# ASIC for iob-soc
+asic:  $(VSRC) $(VHDR)
+	mkdir -p $(OPENLANE_DESIGNS)/system/src 
+	cp $(VSRC) $(VHDR) $(OPENLANE_DESIGNS)/system/src 
+	cd $(OPENLANE_HOME);
+	$(DOK_CMD) sh -c   "./flow.tcl -design system  -init_design_config"
+	$(DOK_CMD) sh -c   "./flow.tcl -design system  -tag soc -overwrite"
+	 	
 
 copy_test:  $(VSRC) $(VHDR)
 	mkdir temp
@@ -39,6 +42,9 @@ debug:
 	echo $(VSRC)
 	echo $(VHDR)
 
-clean:
+clean_sram:
 	rm -rf __pycache__
 	rm -rf sram
+clean_asic:
+	cd $(OPENLANE_DESIGNS);
+		rm -rf system	

--- a/hardware/asic/skywater/Makefile
+++ b/hardware/asic/skywater/Makefile
@@ -14,7 +14,7 @@ IMAGE_NAME ?= efabless/openlane:2021.07.29_04.49.46 #latest
 ifeq (0,$(shell docker -v 2>/dev/null | grep podman | wc -l))
    DOCKER_UID_OPTIONS = -u $(shell id -u $(USER)):$(shell id -g $(USER))
 endif
-DOK_CMD ?= docker run --rm -v $(OPENLANE_HOME):/openLANE_flow -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT) $(DOCKER_UID_OPTIONS) $(IMAGE_NAME)
+DOK_CMD ?= docker run -it --rm -v $(OPENLANE_HOME):/openLANE_flow -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT) $(DOCKER_UID_OPTIONS) $(IMAGE_NAME)
 
 .PHONY: all asic clean_sram clean_asic
 


### PR DESCRIPTION
Hi Sir,
I have made following changes in Makefile and now it is working with make asic. Complete flow of OpenLane is working.
1. " " with DOK_CMD were not required and were removed.
2. VSRC and VHDR never copied UART sw_reg.v which ws required by the yosys to synthesize. I manually copied it. So this must be  fixed.
3. For gen_if.v like files were only interface definition is defined like ( `INPUT ) yosys gives error [unexpected TOK_INPUT] and also in UART sw_reg.v which has definition like ( `SWREG)  yosys gives error [unexpected TOK_REG]. I replaced it with definition of the `SWREG from iob_lib. And after these changes yosys was able to compile the src.
4. PDK_ROOT that you specified is the default one. It is perfectly ok. But if you want to specify some other path for it, you can export it during the installation of OpenLane. This is explained in README and I have added one more line to it.
5. DOK_CMD will run twice once for generating config.tcl configuration of the design and the other time for soc flow
6. I have changed the name of the design of the iob-soc inside the designs folder to system. This is important since the name of the design should be same as the name of the top level module is. In our case name of the top level module is system.v
regards