### PR TITLE
Makefile src files issue resolved 

### DIFF
--- a/hardware/asic/skywater/Makefile
+++ b/hardware/asic/skywater/Makefile
@@ -22,13 +22,13 @@ sram: asic_config.py
 
 # ASIC generation
 asic:  $(VSRC) $(VHDR)
-	mkdir -p $(OPENLANE_DESIGNS)/system_core/src 
-	mkdir -p $(OPENLANE_DESIGNS)/system_core/inc 
-	cp $(VSRC) $(OPENLANE_DESIGNS)/system_core/src 
-	cp $(VHDR) $(OPENLANE_DESIGNS)/system_core/inc 
-	cp config.tcl $(OPENLANE_DESIGNS)/system_core
+	mkdir -p $(OPENLANE_DESIGNS)/system/src 
+	mkdir -p $(OPENLANE_DESIGNS)/system/inc 
+	cp $(VSRC) $(OPENLANE_DESIGNS)/system/src 
+	cp $(VHDR) $(OPENLANE_DESIGNS)/system/inc 
+	cp config.tcl $(OPENLANE_DESIGNS)/system
 	cd $(OPENLANE_HOME);
-	$(DOK_CMD) sh -c   "./flow.tcl -design system_core  -p "read_verilog -I/$(OPENLANE_DESIGNS)/system_core/inc" -tag soc -overwrite -config file /system_core/config.tcl"
+	$(DOK_CMD) sh -c   "./flow.tcl -design system  -p "read_verilog -I/$(OPENLANE_DESIGNS)/system/inc" -tag soc -overwrite -config file /system/config.tcl"
 
 debug:
 	mkdir temp
@@ -41,7 +41,7 @@ clean_sram:
 	rm -rf sram
 
 clean_asic:
-	rm -rf $(OPENLANE_DESIGNS)/system_core
+	rm -rf $(OPENLANE_DESIGNS)/system
 
 clean_debug:
 	rm -rf temp

--- a/hardware/asic/skywater/Makefile
+++ b/hardware/asic/skywater/Makefile
@@ -1,16 +1,16 @@
 
 ROOT_DIR=../../..
 include ../asic.mk
-
+VHDR+= $(UART_DIR)/hardware/include/UARTsw_reg.v
 OPENLANE_DESIGNS:=$(OPENLANE_HOME)/designs
-
 IMAGE_NAME ?= efabless/openlane:2021.07.29_04.49.46 #latest
+
 ifeq (0,$(shell docker -v 2>/dev/null | grep podman | wc -l))
    DOCKER_UID_OPTIONS = -u $(shell id -u $(USER)):$(shell id -g $(USER))
 endif
 DOK_CMD ?= docker run -it --rm -v $(OPENLANE_HOME):/openLANE_flow -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT) $(DOCKER_UID_OPTIONS) $(IMAGE_NAME)
 
-.PHONY: all asic clean_sram clean_asic clean
+.PHONY: all asic clean_sram clean_asic clean_debug clean
 
 all: sram asic
 
@@ -22,11 +22,13 @@ sram: asic_config.py
 
 # ASIC generation
 asic:  $(VSRC) $(VHDR)
-	mkdir -p $(OPENLANE_DESIGNS)/system/src 
-	cp $(VSRC) $(VHDR) $(OPENLANE_DESIGNS)/system/src 
+	mkdir -p $(OPENLANE_DESIGNS)/system_core/src 
+	mkdir -p $(OPENLANE_DESIGNS)/system_core/inc 
+	cp $(VSRC) $(OPENLANE_DESIGNS)/system_core/src 
+	cp $(VHDR) $(OPENLANE_DESIGNS)/system_core/inc 
+	cp config.tcl $(OPENLANE_DESIGNS)/system_core
 	cd $(OPENLANE_HOME);
-	$(DOK_CMD) sh -c   "./flow.tcl -design system  -init_design_config"
-	$(DOK_CMD) sh -c   "./flow.tcl -design system  -tag soc -overwrite"
+	$(DOK_CMD) sh -c   "./flow.tcl -design system_core  -p "read_verilog -I/$(OPENLANE_DESIGNS)/system_core/inc" -tag soc -overwrite -config file /system_core/config.tcl"
 
 debug:
 	mkdir temp
@@ -39,6 +41,9 @@ clean_sram:
 	rm -rf sram
 
 clean_asic:
-	rm -rf $(OPENLANE_DESIGNS)/system
+	rm -rf $(OPENLANE_DESIGNS)/system_core
 
-clean: clean_sram clean_asic
+clean_debug:
+	rm -rf temp
+
+clean: clean_sram clean_asic clean_debug

--- a/hardware/asic/skywater/build.sh
+++ b/hardware/asic/skywater/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+flow.tcl -interactive
+prep -design system_core
+run_yosys -p "read_verilog -I/$(OPENLANE_DESIGNS)/system_core/inc"
+run_sta
+run_floorplan
+run_placement_step
+run_cts_step
+run_routing_step
+run_diode_insertion_2_5_step
+run_power_pins_insertion_step
+run_magic
+run_klayout
+run_klayout_gds_xor
+run_lef_cvc
+
+

--- a/hardware/src/system_core.v
+++ b/hardware/src/system_core.v
@@ -5,7 +5,7 @@
 //do not remove line below
 //PHEADER
 
-module system_core 
+module system 
   (
    //do not remove line below
    //PIO

--- a/hardware/src/system_core.v
+++ b/hardware/src/system_core.v
@@ -5,7 +5,7 @@
 //do not remove line below
 //PHEADER
 
-module system 
+module system_core 
   (
    //do not remove line below
    //PIO


### PR DESCRIPTION
Hi Sir,
I have resolved the Makefile issue of src files. Now we will add the config.tcl file to the Skywater folder and Makfefile will copy it to the designs/system_core folder. User can change config.tcl to add any other option as specified in README.md. 
Now I am working on memory generation. Build.sh is there in the folder, but it may or may not be required, I will decide it after the sram macro placement is added to the Makefile
One more thing is that the name of the module in system_core.v file has been changed to system_core. Since OpenLane requires the name of file and module to be the same. 
regards