### PR TITLE
Targets for sram Macro placement

### DIFF
--- a/hardware/asic/skywater/Makefile
+++ b/hardware/asic/skywater/Makefile
@@ -2,36 +2,54 @@
 ROOT_DIR=../../..
 include ../asic.mk
 VHDR+= $(UART_DIR)/hardware/include/UARTsw_reg.v
+VSRC+=iob_dp_ram.v
 OPENLANE_DESIGNS:=$(OPENLANE_HOME)/designs
 IMAGE_NAME ?= efabless/openlane:2021.07.29_04.49.46 #latest
+
+# Memory technology
+ASIC_MEM_TECH:=skywater130
+
+# Memory type
+ASIC_DPRAM_TYPE:=SH
 
 ifeq (0,$(shell docker -v 2>/dev/null | grep podman | wc -l))
    DOCKER_UID_OPTIONS = -u $(shell id -u $(USER)):$(shell id -g $(USER))
 endif
 DOK_CMD ?= docker run -it --rm -v $(OPENLANE_HOME):/openLANE_flow -v $(PDK_ROOT):$(PDK_ROOT) -e PDK_ROOT=$(PDK_ROOT) $(DOCKER_UID_OPTIONS) $(IMAGE_NAME)
 
-.PHONY: all asic clean_sram clean_asic clean_debug clean
+.PHONY: all asic clean_sram clean_asic clean_debug clean_iob_dp_ram clean
 
-all: sram asic
+all: sram iob_dp_ram asic 
 
 #SRAM generation
 
-sram: asic_config.py
-	python3 $(OPENRAM_HOME)/openram.py asic_config.py
+sram: openram_config.py
+	python3 $(OPENRAM_HOME)/openram.py openram_config.py
 	mv temp sram
+#SRAM wrapper generation
 
-
+iob_dp_ram.v:
+#It was added for test only -will be removed-
+#	~/Documents/iob-mem/software/python/memakerwrap.py $(ASIC_MEM_TECH) iob_dp_ram $(ASIC_DPRAM_TYPE) 0 1 $(SRAM_W) 8 4 1 > $@
+	$(MEM_DIR)/software/python/memakerwrap.py $(ASIC_MEM_TECH) iob_dp_ram $(ASIC_DPRAM_TYPE) 0 1 $(SRAM_W) 8 4 1 > $@
 # ASIC generation
 asic:  $(VSRC) $(VHDR)
 	mkdir -p $(OPENLANE_DESIGNS)/system/src 
 	mkdir -p $(OPENLANE_DESIGNS)/system/inc 
+	mkdir -p $(OPENLANE_DESIGNS)/system/macros/lef
+	mkdir -p $(OPENLANE_DESIGNS)/system/macros/gds
+	cp sram/*.lef $(OPENLANE_DESIGNS)/system/macros/lef 	
+	cp sram/*.gds $(OPENLANE_DESIGNS)/system/macros/gds 		
 	cp $(VSRC) $(OPENLANE_DESIGNS)/system/src 
 	cp $(VHDR) $(OPENLANE_DESIGNS)/system/inc 
+	cp run_interactive.tcl $(OPENLANE_HOME)
 	cp config.tcl $(OPENLANE_DESIGNS)/system
 	cd $(OPENLANE_HOME);
-	$(DOK_CMD) sh -c   "./flow.tcl -design system  -p "read_verilog -I/$(OPENLANE_DESIGNS)/system/inc" -tag soc -overwrite -config file /system/config.tcl"
-
-debug:
+# For non-interactive flow of OpenLane by using iob-soc SRAM and macro placement config file -please do not remove-
+	#$(DOK_CMD) sh -c   "./flow.tcl -design system  -p "read_verilog -I/$(OPENLANE_DESIGNS)/system/inc" -tag soc -overwrite -config file /system/config.tcl"
+#For interactive flow for SRAM Macro placement
+	$(DOK_CMD) sh -c "./flow.tcl -interactive -file run_interactive.tcl"
+debug: 
 	mkdir temp
 	cp $(VSRC) $(VHDR) temp
 	echo $(VSRC)
@@ -43,8 +61,11 @@ clean_sram:
 
 clean_asic:
 	rm -rf $(OPENLANE_DESIGNS)/system
-
+	rm -rf iob_dp_ram.v
+	rm -rf $(OPENLANE_HOME)/run_interactive.tcl
+clean_iob_dp_ram:
+	rm -rf iob_dp_ram.v
 clean_debug:
 	rm -rf temp
 
-clean: clean_sram clean_asic clean_debug
+clean: clean_sram clean_asic clean_debug clean_iob_dp_ram

--- a/hardware/asic/skywater/build.sh
+++ b/hardware/asic/skywater/build.sh
@@ -1,18 +1,26 @@
-#!/bin/bash
-
-flow.tcl -interactive
-prep -design system_core
-run_yosys -p "read_verilog -I/$(OPENLANE_DESIGNS)/system_core/inc"
+#!usr/bin/env bash
+./flow.tcl -interactive 
+prep -design system config file /system/config.tcl -tag soc -overwrite
+run_yosys -p "read_verilog -I/$(OPENLANE_DESIGNS)/system/inc"
 run_sta
-run_floorplan
-run_placement_step
-run_cts_step
-run_routing_step
-run_diode_insertion_2_5_step
-run_power_pins_insertion_step
+init_floorplan
+add_macro_placement ram 5.59000 168.23 N
+manual_macro_placement f
+place_io
+tap_decap_or
+gen_pdn
+write_powered_verilog
+set_netlist $::env(lvs_result_file_tag).powered.v
+global_placement_or
+detailed_placement_or
+run_cts
+global_routing
+detailed_routing
 run_magic
-run_klayout
-run_klayout_gds_xor
-run_lef_cvc
-
-
+run_magic_drc
+puts $::env(CURRENT_NETLIST)
+run_magic_spice_export
+run_lvs
+run_antenna_check
+calc_total_runtime
+generate_final_summary_report

--- a/hardware/asic/skywater/config.tcl
+++ b/hardware/asic/skywater/config.tcl
@@ -1,6 +1,6 @@
 # User config
 
-set ::env(DESIGN_NAME) system_core
+set ::env(DESIGN_NAME) system
 
 # Change if needed
 set ::env(VERILOG_FILES) "src/*.v"
@@ -8,7 +8,19 @@ set ::env(VERILOG_FILES) "src/*.v"
 # Fill this
 set ::env(CLOCK_PERIOD) "10"
 set ::env(CLOCK_PORT) "clk"
+#for non interactive macro placement -please do not remove-
+#set ::env(MACRO_PLACEMENT_CFG) $::env(OPENLANE_HOME)/designs/$::env(DESIGN_NAME)/macro_placement.cfg
 
+#variables to set macro to be placed as macro (not core i.e., without io ring/pad)
+set ::env(DESIGN_IS_CORE) 0
+set ::env(FP_PDN_CORE_RING) 0
+#variables to prohibit router from using metal 5 for routing. Router will use up to met4 before macro placement
+set ::env(GLB_RT_MAXLAYER) 5
+#lef and gds files from generated OpenRAM (sram)
+set ::env(EXTRA_LEFS) [glob $::env(DESIGN_DIR)/macros/lef/*.lef]
+set ::env(EXTRA_GDS_FILES) [glob $::env(DESIGN_DIR)/macros/gds/*.gds]
+set ::env(DIE_AREA) "0 0 812.060 422.780"
+set ::env(FP_SIZING) absolute
 set filename $::env(DESIGN_DIR)/$::env(PDK)_$::env(STD_CELL_LIBRARY)_config.tcl
 if { [file exists $filename] == 1} {
 	source $filename

--- a/hardware/asic/skywater/openram_config.py
+++ b/hardware/asic/skywater/openram_config.py
@@ -1,18 +1,21 @@
 
 # Data word size
 word_size = 32
+num_rw_ports = 1
+num_r_ports = 0
+num_w_ports = 0
 
 # Number of words in the memory
-num_words = 1024
+num_words = 64
 
 # Technology to use in $OPENRAM_TECH
 tech_name = "sky130A"
 
 # You can use the technology nominal corner only
-# nominal_corner_only = True
+#nominal_corner_only = True
 
-process_corners = ["SS", "TT", "FF"]
-# process_corners = ["TT"]
+#process_corners = ["SS", "TT", "FF"]
+process_corners = ["TT"]
 
 # Voltage corners to characterize
 supply_voltages = [ 1.8 ]

--- a/hardware/asic/skywater/run_interactive.tcl
+++ b/hardware/asic/skywater/run_interactive.tcl
@@ -1,0 +1,27 @@
+#Interactive commands
+package require openlane
+prep -design system config file /system/config.tcl -tag soc -overwrite
+run_yosys -p "read_verilog -I/designs/system/inc"
+run_sta
+init_floorplan
+add_macro_placement ram 5.59000 168.23 N
+manual_macro_placement f
+place_io
+tap_decap_or
+gen_pdn
+write_powered_verilog
+set_netlist $::env(lvs_result_file_tag).powered.v
+global_placement_or
+detailed_placement_or
+run_cts
+global_routing
+detailed_routing
+run_magic
+run_magic_drc
+#these commands are valid and will be used once above cmds are verified -please do not remove-
+#puts $::env(CURRENT_NETLIST)
+#run_magic_spice_export
+#run_lvs
+#run_antenna_check
+#calc_total_runtime
+#generate_final_summary_report

--- a/hardware/asic/skywater/run_interactive.tcl
+++ b/hardware/asic/skywater/run_interactive.tcl
@@ -1,4 +1,5 @@
 #Interactive commands
+
 package require openlane
 prep -design system config file /system/config.tcl -tag soc -overwrite
 run_yosys -p "read_verilog -I/designs/system/inc"


### PR DESCRIPTION
Hi,
Sir this PR has changes in Makefile plus other files added in order to place sram macro 
to wrapper black box. 
I have made changes to memakerwrap.py after discussion with Joao in order to add Skywater130 tech to 
it.
Now there are two issues in flow of OpenLane
1 What is the name of the top level module of iob-soc, since openlane requires this in order to synthesize the design. If I set it as "system" because of system.v as top level file it complains in iob_uart.v that no such module name as "system"
2 Even though I generate my wrapper (means wrapper of Skywater130) and add it to VSRC in Makefile. Yosys still compiles iob_tdp_ram.v why it still has this even though if I debug VSRC it does not have this file and iob_tdp_ram.v is not copied to the folder of "src" aswell
best regards
