### PR TITLE
Just changed the target density in config.tcl

### DIFF
--- a/hardware/asic/skywater/config.tcl
+++ b/hardware/asic/skywater/config.tcl
@@ -7,7 +7,7 @@ set ::env(CLOCK_PERIOD) "10"
 set ::env(CLOCK_PORT) "clk"
 set ::env(DESIGN_IS_CORE) 0
 set ::env(FP_PDN_CORE_RING) 0
-set ::env(PL_TARGET_DENSITY) 0.5
+set ::env(PL_TARGET_DENSITY) 0.3
 set ::env(PL_BASIC_PLACEMENT) 1
 set ::env(CELL_PAD) 0
 set ::env(GLB_RESIZER_TIMING_OPTIMIZATIONS) 0


### PR DESCRIPTION
Hi
I just changed the target density in config.tcl. The value is changed to keep a balance in target density. If the target density is large we get the antenna violations and if too small we get routing congestion errors. 
Kindly, have a look.
regards