### PR TITLE
Verilator

### DIFF
--- a/hardware/simulation/cocotb/system_tb.py
+++ b/hardware/simulation/cocotb/system_tb.py
@@ -18,41 +18,6 @@ async def time_limit(duration_ns):
     await Timer(duration_ns, units="ns")
     exit()
 
-#@cocotb.test()
-async def basic_test(dut):
-    reset_n = dut.reset
-    clk_n = dut.clk
-    char = 0
-
-    cocotb.start_soon(Clock(clk_n, CLK_PERIOD, units="ns").start())
-    await reset_dut(reset_n, 100*CLK_PERIOD)
-    await Timer(10*CLK_PERIOD, units="ns")  # wait a bit
-    dut.uart_valid.value = 0
-    dut.uart_wstrb.value = 0
-    await inituart(dut)
-
-    print('\n\nTESTBENCH: connecting')
-    while(char != 4):
-        #print("traped")
-        if(dut.trap.value.integer > 0):
-            print('TESTBENCH: force cpu trap exit')
-            exit()
-        RXready = 0
-        TXready = 0
-        while(RXready != 1 and TXready != 1):
-            RXready = await uartread(dut, UART_RXREADY_ADDR)
-            TXready = await uartread(dut, UART_TXREADY_ADDR)
-            #print(":p")
-        if(RXready):
-            char = await uartread(dut, UART_RXDATA_ADDR)
-            print(chr(char), end = '')
-            sys.stdout.flush()
-        elif(TXready):
-            if(char == 5):
-                send = 6
-                await uartwrite(dut, UART_TXDATA_ADDR, send)
-    print('\nTESTBENCH: finished\n\n')
-
 @cocotb.test()
 async def files_tb_test(dut):
     char = 0

--- a/hardware/testbench/system_core_tb.v
+++ b/hardware/testbench/system_core_tb.v
@@ -244,18 +244,18 @@ module system_tb;
        .ADDR_WIDTH (`DDR_ADDR_W)
        )
    ddr_model_mem(
-                 //address write
-                 .clk            (clk),
-                 .rst            (reset),
+		 //address write
+		 .clk            (clk),
+		 .rst            (reset),
 		 .s_axi_awid     ({8{ddr_awid}}),
 		 .s_axi_awaddr   (ddr_awaddr[`DDR_ADDR_W-1:0]),
-                 .s_axi_awlen    (ddr_awlen),
-                 .s_axi_awsize   (ddr_awsize),
-                 .s_axi_awburst  (ddr_awburst),
-                 .s_axi_awlock   (ddr_awlock),
+		 .s_axi_awlen    (ddr_awlen),
+		 .s_axi_awsize   (ddr_awsize),
+		 .s_axi_awburst  (ddr_awburst),
+		 .s_axi_awlock   (ddr_awlock),
 		 .s_axi_awprot   (ddr_awprot),
 		 .s_axi_awcache  (ddr_awcache),
-     		 .s_axi_awvalid  (ddr_awvalid),
+		 .s_axi_awvalid  (ddr_awvalid),
 		 .s_axi_awready  (ddr_awready),
 
 		 //write
@@ -263,12 +263,12 @@ module system_tb;
 		 .s_axi_wready   (ddr_wready),
 		 .s_axi_wdata    (ddr_wdata),
 		 .s_axi_wstrb    (ddr_wstrb),
-                 .s_axi_wlast    (ddr_wlast),
+		 .s_axi_wlast         (ddr_wlast),
 
 		 //write response
 		 .s_axi_bready   (ddr_bready),
-                 .s_axi_bid      (ddr_bid),
-                 .s_axi_bresp    (ddr_bresp),
+		 .s_axi_bid      (ddr_bid),
+		 .s_axi_bresp    (ddr_bresp),
 		 .s_axi_bvalid   (ddr_bvalid),
 
 		 //address read
@@ -276,10 +276,10 @@ module system_tb;
 		 .s_axi_araddr   (ddr_araddr[`DDR_ADDR_W-1:0]),
 		 .s_axi_arlen    (ddr_arlen),
 		 .s_axi_arsize   (ddr_arsize),
-                 .s_axi_arburst  (ddr_arburst),
-                 .s_axi_arlock   (ddr_arlock),
-                 .s_axi_arcache  (ddr_arcache),
-                 .s_axi_arprot   (ddr_arprot),
+		 .s_axi_arburst  (ddr_arburst),
+		 .s_axi_arlock   (ddr_arlock),
+		 .s_axi_arcache  (ddr_arcache),
+		 .s_axi_arprot   (ddr_arprot),
 		 .s_axi_arvalid  (ddr_arvalid),
 		 .s_axi_arready  (ddr_arready),
 
@@ -288,9 +288,9 @@ module system_tb;
 		 .s_axi_rid      (ddr_rid),
 		 .s_axi_rdata    (ddr_rdata),
 		 .s_axi_rresp    (ddr_rresp),
-                 .s_axi_rlast    (ddr_rlast),
+		 .s_axi_rlast    (ddr_rlast),
 		 .s_axi_rvalid   (ddr_rvalid)
-                 );
+		 );
 `endif
 
 

--- a/hardware/testbench/system_core_tb.v
+++ b/hardware/testbench/system_core_tb.v
@@ -72,7 +72,7 @@ module system_tb;
     txread_reg = 0;
 
 
-    soc2cnsl_fd = $fopen("soc2cnsl", "rb+");
+    soc2cnsl_fd = $fopen("soc2cnsl", "r+");
     if (!soc2cnsl_fd) begin
       $display("Could not open \"soc2cnsl\"");
       $finish;
@@ -85,10 +85,6 @@ module system_tb;
         //$write("Loop %d: RX = %x; TX = %x\n", i, rxread_reg[0], txread_reg[0]);
         cpu_uartread(`UART_RXREADY_ADDR, rxread_reg);
         cpu_uartread(`UART_TXREADY_ADDR, txread_reg);
-        //i = i+1;
-        //if(i>10000) begin
-        //  #20 $finish;
-        //end
       end
       if(rxread_reg) begin
         n = $fgets(cpu_char, soc2cnsl_fd);
@@ -102,7 +98,7 @@ module system_tb;
       end
       if(txread_reg) begin
         //$write("Enter TX\n");
-        cnsl2soc_fd = $fopen("cnsl2soc", "rb+");
+        cnsl2soc_fd = $fopen("cnsl2soc", "r");
         if (!cnsl2soc_fd) begin
           //$write("Could not open file cnsl2soc!\n");
           $fclose(soc2cnsl_fd);

--- a/software/console/console
+++ b/software/console/console
@@ -30,8 +30,8 @@ def tb_write(data, number_of_bytes = 1):
     while(transfered_bytes < number_of_bytes):
         while (os.path.getsize("./cnsl2soc") != 0):
             pass
-        f = open('./cnsl2soc', "w")
-        f.write(chr(data[transfered_bytes]))
+        f = open('./cnsl2soc', "wb")
+        f.write(data[transfered_bytes].to_bytes(1, byteorder='little'))
         f.flush()
         transfered_bytes += 1
         new_percentage = int(100/number_of_bytes*transfered_bytes)


### PR DESCRIPTION
Both icarus and cocotb simulation fully work with console in python.
Timing is similar to the last pull request. 
With INIT_MEM = 0 icarus took 13 min and cocotb took 47 min.