### PR TITLE
Verilator

### DIFF
--- a/hardware/simulation/icarus/Makefile
+++ b/hardware/simulation/icarus/Makefile
@@ -4,15 +4,16 @@ defmacro:=-D
 incdir:=-I
 
 CONSOLE_CMD=../../../software/console/console -L
-ifeq ($(INIT_MEM),0)
-	CONSOLE_CMD+=-f
-endif
 SIMULATOR=icarus
 SIM_SERVER=$(IVSIM_SERVER)
 SIM_USER=$(IVSIM_USER)
 SIM_PROC=a.out
 
 include ../simulation.mk
+
+ifeq ($(INIT_MEM),0)
+	CONSOLE_CMD+=-f
+endif
 
 #simulator flags
 VLOG = iverilog -W all -g2005-sv $(INCLUDE) $(DEFINE)

--- a/hardware/simulation/verilator/Makefile
+++ b/hardware/simulation/verilator/Makefile
@@ -10,12 +10,12 @@ SIM_USER=$(VSIM_USER)
 SIM_PROC=Vsystem
 
 CONSOLE_CMD=../../../software/console/console -L
-ifeq ($(INIT_MEM),0)
-	CONSOLE_CMD+=-f
-endif
 
 include ../simulation.mk
 
+ifeq ($(INIT_MEM),0)
+	CONSOLE_CMD+=-f
+endif
 # remove space between -I and directory for verilator
 INCLUDE_VERI=$(subst -I ,-I,$(INCLUDE))
 

--- a/hardware/simulation/verilator/Makefile
+++ b/hardware/simulation/verilator/Makefile
@@ -41,12 +41,12 @@ VERILATOR_COVERAGE = $(VERILATOR_ROOT)/bin/verilator_coverage
 endif
 
 # Verilator flags
-VERILATOR_FLAGS += -cc --exe --build# Generate C++ in executable form and compile it after
+VERILATOR_FLAGS += -cc --exe --build # Generate C++ in executable form and compile it after
 #VERILATOR_FLAGS += -MMD # Generate makefile dependencies (not shown as complicates the Makefile)
 #VERILATOR_FLAGS += -Os -x-assign 0 # Optimize
-VERILATOR_FLAGS += -Wall # Warn abount lint issues; may not want this on less solid designs
-VERILATOR_FLAGS += -Wno-lint -Wno-WIDTH -Wno-PINMISSING -Wno-CASEINCOMPLETE # Disable the warnings
-#VERILATOR_FLAGS += --bbox-unsup # Disable the warning that the code has an assignment statement with a delayed time in front of it
+VERILATOR_FLAGS += -Wall # Enable all style warnings; may not want this on less solid designs
+VERILATOR_FLAGS += -Wno-lint # Disable all lint warnings
+#VERILATOR_FLAGS += -Wno-fatal # Disable fatal exit on warnings
 VERILATOR_FLAGS += --trace # Make waveforms
 #VERILATOR_FLAGS += --assert # Check SystemVerilog assertions
 #VERILATOR_FLAGS += --coverage # Generate coverage analysis

--- a/hardware/simulation/verilator/Makefile
+++ b/hardware/simulation/verilator/Makefile
@@ -46,7 +46,7 @@ VERILATOR_FLAGS += -cc --exe --build # Generate C++ in executable form and compi
 #VERILATOR_FLAGS += -Os -x-assign 0 # Optimize
 VERILATOR_FLAGS += -Wall # Enable all style warnings; may not want this on less solid designs
 VERILATOR_FLAGS += -Wno-lint # Disable all lint warnings
-#VERILATOR_FLAGS += -Wno-fatal # Disable fatal exit on warnings
+VERILATOR_FLAGS += -Wno-fatal # Disable fatal exit on warnings
 VERILATOR_FLAGS += --trace # Make waveforms
 #VERILATOR_FLAGS += --assert # Check SystemVerilog assertions
 #VERILATOR_FLAGS += --coverage # Generate coverage analysis
@@ -62,6 +62,7 @@ VERILATOR_INPUT = $(INCLUDE_VERI) $(DEFINE) $(VSRC) --top-module system_top syst
 run: $(VSRC) $(VHDR) $(IMAGES)
 	$(VERILATOR) $(VERILATOR_FLAGS) $(VERILATOR_INPUT)
 	-pkill -f console
+	-rm soc2cnsl cnsl2soc
 	$(CONSOLE_CMD) &
 	cp obj_dir/Vsystem_top Vsystem_top
 	./Vsystem_top

--- a/hardware/simulation/verilator/system_tb.cpp
+++ b/hardware/simulation/verilator/system_tb.cpp
@@ -20,8 +20,6 @@
 #define BAUD 5000000
 #define CLK_PERIOD 10000 // 20 ns
 
-#define CONSOLE_DIR "../../../software/console/"
-
 vluint64_t main_time = 0;
 VerilatedVcdC* tfp = NULL;
 Vsystem_top* dut = NULL;
@@ -105,7 +103,7 @@ int main(int argc, char **argv, char **env){
   char rxread_reg = 0, txread_reg = 0;
   int n = 0;
 
-  while ((soc2cnsl_fd = fopen("soc2cnsl", "rb+")) == NULL){
+  while ((soc2cnsl_fd = fopen("./soc2cnsl", "rb+")) == NULL){
     //printf("Could not open \"soc2cnsl\"\n");
   }
 
@@ -133,7 +131,7 @@ int main(int argc, char **argv, char **env){
     }
     if(txread_reg){
       //$write("Enter TX\n");
-      if ((cnsl2soc_fd = fopen("cnsl2soc", "rb")) == NULL){
+      if ((cnsl2soc_fd = fopen("./cnsl2soc", "rb")) == NULL){
         //printf("Could not open file cnsl2soc!\n");
         fclose(soc2cnsl_fd);
         break;

--- a/hardware/simulation/verilator/system_tb.cpp
+++ b/hardware/simulation/verilator/system_tb.cpp
@@ -111,6 +111,10 @@ int main(int argc, char **argv, char **env){
   while(1){
     if(dut->trap > 0){
         printf("\nTESTBENCH: force cpu trap exit\n");
+        fclose(soc2cnsl_fd);
+        soc2cnsl_fd = fopen("./soc2cnsl", "wb");
+        cpu_char = 4;
+        fwrite(&cpu_char, sizeof(char), 1, soc2cnsl_fd);
         break;
     }
     while(!rxread_reg && !txread_reg){
@@ -133,7 +137,6 @@ int main(int argc, char **argv, char **env){
       //$write("Enter TX\n");
       if ((cnsl2soc_fd = fopen("./cnsl2soc", "rb")) == NULL){
         //printf("Could not open file cnsl2soc!\n");
-        fclose(soc2cnsl_fd);
         break;
       }
       n = fread(&cpu_char, sizeof(char), 1, cnsl2soc_fd);
@@ -147,6 +150,7 @@ int main(int argc, char **argv, char **env){
       txread_reg = 0;
     }
   }
+  fclose(soc2cnsl_fd);
   printf("TESTBENCH: finished\n\n");
 
   dut->final();

--- a/software/console/console
+++ b/software/console/console
@@ -179,21 +179,24 @@ def init_serial():
     ser.writeTimeout = 2     #timeout for write
 
 
+def init_files():
+    f = open('./cnsl2soc',"w")
+    f.seek(0) # absolute file positioning
+    f.truncate() # to erase all data
+    f.close()
+    f = open('./soc2cnsl',"w")
+    f.seek(0) # absolute file positioning
+    f.truncate() # to erase all data
+    f.close()
+
+
 def init_console():
     global SerialFlag
     global ser
     load_fw = False
     if ('-L' in sys.argv or '--local' in sys.argv):
         SerialFlag = False
-        f = open('./cnsl2soc',"wb")
-        f.write(b'\x01')
-        f.close()
-        try:
-            open('./soc2cnsl',"x")
-        except IOError as e:
-            print('Old soc2cnsl deleted and created new file!')
-            os.remove('./soc2cnsl')
-            open('./soc2cnsl',"x")
+        init_files()
     elif ('-s' in sys.argv):
         if (len(sys.argv)<3):
             usage("PROGNAME: not enough program arguments")


### PR DESCRIPTION
Verification runs with cache. Warning is still displayed, but the simulation no longer exits due to warnings.

There is a problem, when just running "make sim SIMULATOR=verilator RUN_EXTMEM=1" the simulation ends with a CPU trap condition. This does not occur in the old simulation. 
Running "make sim SIMULATOR=verilator RUN_EXTMEM=1 INIT_MEM=0" works as expected.

Probably, the console, when using the cache, always has to be called with the "-f" flag in order to send the firmware binary file. Just like it happens with INIT_MEM=0.  I have to check if this is true and then make the changes for it to happen.