### PR TITLE
INIT_MEM=0 should be set manually

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -74,7 +74,6 @@ UART_HW_DIR:=$(UART_DIR)/hardware
 ifeq ($(RUN_EXTMEM),1)
 DEFINE+=$(defmacro)RUN_EXTMEM
 USE_DDR=1
-INIT_MEM=0
 endif
 
 ifeq ($(USE_DDR),1)


### PR DESCRIPTION
When running with RUN_EXTMEM=1, INIT_MEM should not be set to 0 automatically.