### PR TITLE
Verilator

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -74,7 +74,6 @@ UART_HW_DIR:=$(UART_DIR)/hardware
 ifeq ($(RUN_EXTMEM),1)
 DEFINE+=$(defmacro)RUN_EXTMEM
 USE_DDR=1
-INIT_MEM=0
 endif
 
 ifeq ($(USE_DDR),1)

--- a/hardware/simulation/verilator/system_tb.cpp
+++ b/hardware/simulation/verilator/system_tb.cpp
@@ -128,10 +128,11 @@ int main(int argc, char **argv, char **env){
         uartread(UART_RXDATA_ADDR, &cpu_char);
         //printf("Test 1! %x\n", cpu_char);
         //$display("%x", cpu_char);
-        fwrite(&cpu_char, sizeof(char), 1, soc2cnsl_fd);
+        n = fwrite(&cpu_char, sizeof(char), 1, soc2cnsl_fd);
+        while(n != 0)
+          n = fseek(soc2cnsl_fd, 0, 0);
         rxread_reg = 0;
       }
-      n = fseek(soc2cnsl_fd, 0, 0);
     }
     if(txread_reg){
       //$write("Enter TX\n");


### PR DESCRIPTION
Updated AXI submodule to last commit.

Fixed a bug where the verilator simulation would get stuck when a fseek call failed. Discovered where the problem was with gdb. Which is nice to know that verilator testbenchs can be debugged with gdb.

And removed automatic INIT_MEM=0 when RUN_EXTMEM = 1. Tried to merge the devel branch but failed. devel branch is not stable and simulation on it does not run.