### PR TITLE
Devel

### DIFF
--- a/hardware/simulation/verilator/test.expected
+++ b/hardware/simulation/verilator/test.expected
@@ -27,7 +27,7 @@ IOb-Bootloader: connected!
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
 IOb-Console: file name b'firmware.bin' 
-IOb-Console: file of size 19108 bytes
+IOb-Console: file of size 19064 bytes
   0 %
  10 %
  20 %
@@ -45,7 +45,7 @@ IOb-Bootloader: Loading firmware...
 IOb-UART: requesting to send file
 IOb-Console: got file receive request
 IOb-Console: file name b's_fw.bin' 
-IOb-Console : file size: 19108 bytes
+IOb-Console : file size: 19064 bytes
   0 %
  10 %
  20 %
@@ -121,7 +121,7 @@ IOb-Bootloader: program to run from DDR
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
 IOb-Console: file name b'firmware.bin' 
-IOb-Console: file of size 19260 bytes
+IOb-Console: file of size 19216 bytes
   0 %
  10 %
  20 %
@@ -139,7 +139,7 @@ IOb-Bootloader: Loading firmware...
 IOb-UART: requesting to send file
 IOb-Console: got file receive request
 IOb-Console: file name b's_fw.bin' 
-IOb-Console : file size: 19260 bytes
+IOb-Console : file size: 19216 bytes
   0 %
  10 %
  20 %

--- a/software/console/console
+++ b/software/console/console
@@ -45,8 +45,8 @@ def tb_read(number_of_bytes, is_file = False):
     data = b''
     transfered_bytes = 0
     read_percentage = 100
+    f = open('./soc2cnsl', "rb+")
     while(transfered_bytes < number_of_bytes):
-        f = open('./soc2cnsl', "rb+")
         byte = f.read(1)
         if(byte!=b''):
             data += byte
@@ -58,7 +58,7 @@ def tb_read(number_of_bytes, is_file = False):
                     if (not read_percentage%10): print("%3d %c" % (read_percentage, '%'))
             f.seek(0) # absolute file positioning
             f.truncate() # to erase all data
-        f.close()
+    f.close()
     return data
 
 # Print ERROR


### PR DESCRIPTION
The console was reading IOB-UART, but printing it to the s_fw.bin file. That is why it seamed as it was eating characters.
I made a small alteration to the console that seems to have fixed it.

Also altered the expected files size to pass the tests.