### PR TITLE
fix(console): usage error, update SERIAL

### DIFF
--- a/software/console/Makefile
+++ b/software/console/Makefile
@@ -1,6 +1,7 @@
 ROOT_DIR:=../..
 include $(ROOT_DIR)/config.mk
 
+# Need to add udev rule to have this symlink
 SERIAL:=/dev/usb-uart
 TEST_BENCH:=0
 

--- a/software/console/console
+++ b/software/console/console
@@ -126,7 +126,7 @@ def cnsl_recvfile():
     print(': file received'.format(file_size))
 
 def usage(message):
-    cnsl_perror("usage: ./console -s <serial port> [ -f ] [ -L/--local ]")
+    print('{}:{}'.format(PROGNAME, "usage: ./console -s <serial port> [ -f ] [ -L/--local ]"))
     cnsl_perror(message)
 
 def clean_exit():


### PR DESCRIPTION
- Update SERIAL path, note that this now assumes a SYMLINK to
  `/dev/usb-uart`.
    - This fixes problems related to the same device beeing attributed a
      random value in `/dev/ttyUSBx` that can vary from boot to boot
- Fix `usage()` function
    - previous implementation called `cnsl_perror()` twice:
        - 1st time prints usage
        - 2nd time prints error message
    - however `cnsl_perror()` calls `exit(1)`, so the error message is
      never printed
    - Now `usage()` prints usage message and calls `cnsl_perror()`