### PR TITLE
fix(sw): Warning for possible misaligned accesses

### DIFF
--- a/software/console/Makefile
+++ b/software/console/Makefile
@@ -1,6 +1,7 @@
 ROOT_DIR:=../..
 include $(ROOT_DIR)/config.mk
 
+# Need to add udev rule to have this symlink
 SERIAL:=/dev/usb-uart
 TEST_BENCH:=0
 

--- a/software/console/console
+++ b/software/console/console
@@ -126,7 +126,7 @@ def cnsl_recvfile():
     print(': file received'.format(file_size))
 
 def usage(message):
-    cnsl_perror("usage: ./console -s <serial port> [ -f ] [ -L/--local ]")
+    print('{}:{}'.format(PROGNAME, "usage: ./console -s <serial port> [ -f ] [ -L/--local ]"))
     cnsl_perror(message)
 
 def clean_exit():

--- a/software/software.mk
+++ b/software/software.mk
@@ -7,7 +7,7 @@ DEFINE+=$(defmacro)FREQ=$(FREQ)
 
 #compiler settings
 TOOLCHAIN_PREFIX:=riscv64-unknown-elf-
-CFLAGS=-Os -nostdlib -march=$(MFLAGS) -mabi=ilp32 --specs=nano.specs
+CFLAGS=-Os -nostdlib -march=$(MFLAGS) -mabi=ilp32 --specs=nano.specs -Wcast-align=strict
 LFLAGS+= -Wl,-Bstatic,-T,../template.lds,--strip-debug
 LLIBS=-lgcc -lc -lnosys
 


### PR DESCRIPTION
- Add `-Wcast-align=strict` flag to riscv toolchain compilation
    - This warns developer to potential risks of cpu trap conditions
- See https://github.com/IObundle/iob-soc/issues/369 for more details