### PR TITLE
Fix bug in firmware.S

### DIFF
--- a/software/firmware/firmware.S
+++ b/software/firmware/firmware.S
@@ -12,7 +12,11 @@ jal ra, main
 
 //reboot to run bootloader
 li s5, 3
+#ifdef RUN_EXTMEM
 li s6, BOOTCTR_BASE | EXTRA_BASE
+#else
+li s6, BOOTCTR_BASE
+#endif
 sw s5, 0(s6)//cpu_rst_req=1, boot=1
 
 ebreak


### PR DESCRIPTION
Without this fix, the cpu 'trap' signal would trigger when returning from the firmware's main function in a system with multiple peripherals.