### PR TITLE
Fix tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ fw-build:
 fw-clean:
 	make -C $(FIRM_DIR) clean-all
 
-
 #
 # EMULATE ON PC
 #
@@ -28,7 +27,6 @@ pc-emul-clean: fw-clean
 
 pc-emul-test: pc-emul-clean
 	make -C $(PC_DIR) test
-
 
 #
 # SIMULATE RTL
@@ -64,7 +62,6 @@ fpga-clean: fw-clean
 fpga-test:
 	make -C $(BOARD_DIR) test
 
-
 #
 # SYNTHESIZE AND SIMULATE ASIC
 #
@@ -85,6 +82,7 @@ asic-test:
 #
 # COMPILE DOCUMENTS
 #
+
 doc-build:
 	make -C $(DOC_DIR) $(DOC).pdf
 
@@ -94,10 +92,11 @@ doc-clean:
 doc-test:
 	make -C $(DOC_DIR) test
 
-doc-test-clean:
-	make -C $(DOC_DIR) test-clean
+#
+# CLEAN
+#
 
-
+clean: pc-emul-clean sim-clean fpga-clean doc-clean
 
 #
 # TEST ALL PLATFORMS
@@ -132,8 +131,10 @@ test-asic-clean:
 	make asic-clean ASIC_NODE=skywater
 
 test-doc:
-	make fpga-clean-all
-	make fpga-build-all
+	make fpga-clean BOARD=CYCLONEV-GT-DK
+	make fpga-clean BOARD=AES-KU040-DB-G
+	make fpga-build BOARD=CYCLONEV-GT-DK
+	make fpga-build BOARD=AES-KU040-DB-G
 	make doc-test DOC=pb
 	make doc-test DOC=presentation
 
@@ -145,25 +146,22 @@ test: test-clean test-pc-emul test-sim test-fpga test-doc
 
 test-clean: test-pc-emul-clean test-sim-clean test-fpga-clean test-doc-clean
 
-
 debug:
 	@echo $(UART_DIR)
 	@echo $(CACHE_DIR)
 
 
 .PHONY: fw-build fw-clean \
-	pc-emul-build pc-emul-run pc-emul-clean \
-	pc-emul-test pc-emul-test-clean\
-	sim-build sim-run sim-clean sim-test sim-test-clean\
-	fpga-build fpga-run fpga-clean fpga-test fpga-test-clean\
-	asic-synth asic-synth-clean \
-	asic-sim-post-synth asic-sim-post-synth-clean \
-	asic-test asic-test-clean\
-	doc-build doc-clean doc-test doc-test-clean\
-	test-pc-emul test-pc-emul-clean\
-	test-sim test-sim-clean\
-	test-fpga test-fpga-clean\
-	test-asic test-asic-clean\
-	test-doc test-doc-clean\
-	test test-clean
+	pc-emul-build pc-emul-run pc-emul-clean pc-emul-test \
+	sim-build sim-run sim-clean sim-test \
+	fpga-build fpga-run fpga-clean fpga-test \
+	asic-synth asic-sim-post-synth asic-test \
+	doc-build doc-clean doc-test \
+	clean \
+	test-pc-emul test-pc-emul-clean \
+	test-sim test-sim-clean \
+	test-fpga test-fpga-clean \
+	test-asic test-asic-clean \
+	test-doc test-doc-clean \
+	test test-clean \
 	debug

--- a/document/document.mk
+++ b/document/document.mk
@@ -19,23 +19,10 @@ SWREGS=0
 
 include $(LIB_DIR)/document/document.mk
 
-
-test: clean-all
-ifeq ($(DOC),pb)
-	make -C $(ROOT_DIR) fpga-test
-endif
-	make $(DOC).pdf
-
-$(DOC).pdf:
-	make doc-build 
+test: clean-all $(DOC).pdf
 	diff -q $(DOC).aux test.expected
 
 clean-all: clean
 	rm -f $(DOC).pdf
 
-test-clean:
-	make doc-clean DOC=presentation
-	make doc-clean DOC=pb
-
 .PHONY: test clean-all
-

--- a/hardware/fpga/fpga.mk
+++ b/hardware/fpga/fpga.mk
@@ -28,7 +28,7 @@ endif
 
 FORCE ?= 1
 
-run:
+run: firmware.bin
 ifeq ($(NORUN),0)
 ifeq ($(BOARD_SERVER),)
 	if [ ! -f $(LOAD_FILE) ]; then touch $(LOAD_FILE); chown $(USER):dialout $(LOAD_FILE); chmod 664 $(LOAD_FILE); fi;\

--- a/hardware/fpga/fpga.mk
+++ b/hardware/fpga/fpga.mk
@@ -28,9 +28,10 @@ endif
 
 FORCE ?= 1
 
-run: firmware.bin
+run:
 ifeq ($(NORUN),0)
 ifeq ($(BOARD_SERVER),)
+	cp $(FIRM_DIR)/firmware.bin .
 	if [ ! -f $(LOAD_FILE) ]; then touch $(LOAD_FILE); chown $(USER):dialout $(LOAD_FILE); chmod 664 $(LOAD_FILE); fi;\
 	bash -c "trap 'make queue-out' INT TERM KILL; make queue-in; if [ $(FORCE) = 1 -o \"`head -1 $(LOAD_FILE)`\" != \"$(JOB)\" ];\
 	then ../prog.sh; echo $(JOB) > $(LOAD_FILE); fi; $(CONSOLE_CMD) $(TEST_LOG); make queue-out;"

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -74,9 +74,6 @@ firmware.hex: $(FIRM_DIR)/firmware.bin
 	$(PYTHON_DIR)/makehex.py $< $(FIRM_ADDR_W) > $@
 	$(PYTHON_DIR)/hex_split.py firmware .
 
-firmware.bin: $(FIRM_DIR)/firmware.bin
-	cp $< .
-
 #clean general hardware files
 hw-clean: gen-clean
 	@rm -f *.v *.vh *.hex *.bin $(SRC_DIR)/system.v $(TB_DIR)/system_tb.v

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -68,15 +68,17 @@ system.v: $(SRC_DIR)/system_core.v
 PYTHON_DIR=$(MEM_DIR)/software/python
 
 boot.hex: $(BOOT_DIR)/boot.bin
-	$(PYTHON_DIR)/makehex.py $(BOOT_DIR)/boot.bin $(BOOTROM_ADDR_W) > boot.hex
+	$(PYTHON_DIR)/makehex.py $< $(BOOTROM_ADDR_W) > $@
 
 firmware.hex: $(FIRM_DIR)/firmware.bin
-	$(PYTHON_DIR)/makehex.py $(FIRM_DIR)/firmware.bin $(FIRM_ADDR_W) > firmware.hex
+	$(PYTHON_DIR)/makehex.py $< $(FIRM_ADDR_W) > $@
 	$(PYTHON_DIR)/hex_split.py firmware .
-	cp $(FIRM_DIR)/firmware.bin .
+
+firmware.bin: $(FIRM_DIR)/firmware.bin
+	cp $< .
 
 #clean general hardware files
 hw-clean: gen-clean
-	@rm -f *.v *.hex *.bin $(SRC_DIR)/system.v $(TB_DIR)/system_tb.v *.vh
+	@rm -f *.v *.vh *.hex *.bin $(SRC_DIR)/system.v $(TB_DIR)/system_tb.v
 
 .PHONY: hw-clean

--- a/hardware/simulation/simulation.mk
+++ b/hardware/simulation/simulation.mk
@@ -56,11 +56,11 @@ endif
 #RULES
 build: $(VSRC) $(VHDR) $(HEXPROGS)
 ifeq ($(SIM_SERVER),)
-	bash -c "trap 'make kill-sim' INT TERM KILL EXIT; make comp"
+	make comp
 else
 	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
 	rsync -avz --delete --force --exclude .git $(SIM_SYNC_FLAGS) $(ROOT_DIR) $(SIM_USER)@$(SIM_SERVER):$(REMOTE_ROOT_DIR)
-	bash -c "trap 'make kill-remote-sim' INT TERM KILL; ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_ROOT_DIR) sim-build SIMULATOR=$(SIMULATOR) INIT_MEM=$(INIT_MEM) USE_DDR=$(USE_DDR) RUN_EXTMEM=$(RUN_EXTMEM) VCD=$(VCD) TEST_LOG=\"$(TEST_LOG)\"'"
+	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_ROOT_DIR) sim-build SIMULATOR=$(SIMULATOR) INIT_MEM=$(INIT_MEM) USE_DDR=$(USE_DDR) RUN_EXTMEM=$(RUN_EXTMEM) VCD=$(VCD) TEST_LOG=\"$(TEST_LOG)\"'
 endif
 
 run: firmware.bin

--- a/hardware/simulation/simulation.mk
+++ b/hardware/simulation/simulation.mk
@@ -63,8 +63,9 @@ else
 	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_ROOT_DIR) sim-build SIMULATOR=$(SIMULATOR) INIT_MEM=$(INIT_MEM) USE_DDR=$(USE_DDR) RUN_EXTMEM=$(RUN_EXTMEM) VCD=$(VCD) TEST_LOG=\"$(TEST_LOG)\"'
 endif
 
-run: firmware.bin
+run:
 ifeq ($(SIM_SERVER),)
+	cp $(FIRM_DIR)/firmware.bin .
 	@rm -f soc2cnsl cnsl2soc
 	$(CONSOLE_CMD) $(TEST_LOG) &
 	bash -c "trap 'make kill-sim' INT TERM KILL EXIT; make exec"

--- a/hardware/simulation/simulation.mk
+++ b/hardware/simulation/simulation.mk
@@ -63,7 +63,7 @@ else
 	bash -c "trap 'make kill-remote-sim' INT TERM KILL; ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) 'make -C $(REMOTE_ROOT_DIR) sim-build SIMULATOR=$(SIMULATOR) INIT_MEM=$(INIT_MEM) USE_DDR=$(USE_DDR) RUN_EXTMEM=$(RUN_EXTMEM) VCD=$(VCD) TEST_LOG=\"$(TEST_LOG)\"'"
 endif
 
-run:
+run: firmware.bin
 ifeq ($(SIM_SERVER),)
 	@rm -f soc2cnsl cnsl2soc
 	$(CONSOLE_CMD) $(TEST_LOG) &


### PR DESCRIPTION
- Add dependency from firmware.bin when running console;
- Fix document targets;
- Cleanup root Makefile;
- Remove dummy trap on simulation build target;
- Simplify boot.hex and firmware.hex targets.