### PR TITLE
Add multi-instance capability; Remove 'pio.vh' and 'inst.vh' file dependency.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ doc-test:
 # CLEAN
 #
 
-clean: pc-emul-clean sim-clean fpga-clean doc-clean
+clean: pc-emul-clean sim-clean fpga-clean doc-clean python-cache-clean
 
 #
 # TEST ALL PLATFORMS
@@ -145,6 +145,9 @@ test-doc-clean:
 test: test-clean test-pc-emul test-sim test-fpga test-doc
 
 test-clean: test-pc-emul-clean test-sim-clean test-fpga-clean test-doc-clean
+
+python-cache-clean:
+	find . -name "*__pycache__" -exec rm -rf {} \; -prune
 
 debug:
 	@echo $(UART_DIR)

--- a/document/presentation/presentation.tex
+++ b/document/presentation/presentation.tex
@@ -142,7 +142,7 @@
 #include "iob-uart.h"
 #include "printf.h"
 
-#include "iob_timer.h"
+#include "iob-timer.h"
 
 int main()
 {

--- a/hardware/fpga/fpga.mk
+++ b/hardware/fpga/fpga.mk
@@ -58,7 +58,7 @@ ifeq ($(FPGA_SERVER),)
 	../build.sh "$(INCLUDE)" "$(DEFINE)" "$(VSRC)" "$(DEVICE)"
 	make post-build
 else 
-	ssh $(BOARD_USER)@$(BOARD_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
+	ssh $(FPGA_USER)@$(FPGA_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
 	rsync -avz --delete --force --exclude .git $(ROOT_DIR) $(FPGA_USER)@$(FPGA_SERVER):$(REMOTE_ROOT_DIR)
 	ssh $(FPGA_USER)@$(FPGA_SERVER) 'make -C $(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD) $@ INIT_MEM=$(INIT_MEM) USE_DDR=$(USE_DDR) RUN_EXTMEM=$(RUN_EXTMEM)'
 	scp $(FPGA_USER)@$(FPGA_SERVER):$(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD)/$(FPGA_OBJ) .
@@ -118,7 +118,7 @@ test3:
 clean-all: hw-clean
 	@rm -f $(FPGA_OBJ) $(FPGA_LOG)
 ifneq ($(FPGA_SERVER),)
-	ssh $(BOARD_USER)@$(BOARD_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
+	ssh $(FPGA_USER)@$(FPGA_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
 	rsync -avz --delete --force --exclude .git $(ROOT_DIR) $(FPGA_USER)@$(FPGA_SERVER):$(REMOTE_ROOT_DIR)
 	ssh $(FPGA_USER)@$(FPGA_SERVER) 'make -C $(REMOTE_ROOT_DIR)/hardware/fpga/$(TOOL)/$(BOARD) clean CLEANIP=$(CLEANIP)'
 endif

--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/verilog/top_system.v
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/verilog/top_system.v
@@ -426,10 +426,10 @@ module top_system(
 `endif
 
                   //UART
-		  .uart_txd      (uart_txd),
-		  .uart_rxd      (uart_rxd),
-		  .uart_rts      (),
-		  .uart_cts      (1'b1)
+		  .UART0_txd      (uart_txd),
+		  .UART0_rxd      (uart_rxd),
+		  .UART0_rts      (),
+		  .UART0_cts      (1'b1)
 		  );
 
 endmodule

--- a/hardware/fpga/quartus/DE10-LITE/verilog/top_system.v
+++ b/hardware/fpga/quartus/DE10-LITE/verilog/top_system.v
@@ -44,10 +44,10 @@ module top_system(
 		  .reset         (sys_rst),
 		  .trap          (trap),
       //UART
-		  .uart_txd      (uart_txd),
-		  .uart_rxd      (uart_rxd),
-		  .uart_rts      (),
-		  .uart_cts      (1'b1)
+		  .UART0_txd      (uart_txd),
+		  .UART0_rxd      (uart_rxd),
+		  .UART0_rts      (),
+		  .UART0_cts      (1'b1)
 		);
 
 endmodule

--- a/hardware/fpga/vivado/AES-KU040-DB-G/verilog/top_system.v
+++ b/hardware/fpga/vivado/AES-KU040-DB-G/verilog/top_system.v
@@ -445,10 +445,10 @@ module top_system(
 `endif
       
       //UART
-      .uart_txd      (uart_txd),
-      .uart_rxd      (uart_rxd),
-      .uart_rts      (),
-      .uart_cts      (1'b1)
+      .UART0_txd      (uart_txd),
+      .UART0_rxd      (uart_rxd),
+      .UART0_rts      (),
+      .UART0_cts      (1'b1)
       );
    
 endmodule

--- a/hardware/fpga/vivado/BASYS3/verilog/top_system.v
+++ b/hardware/fpga/vivado/BASYS3/verilog/top_system.v
@@ -43,10 +43,10 @@ module top_system(
       .trap          (trap),
 
       //UART
-      .uart_txd      (uart_txd),
-      .uart_rxd      (uart_rxd),
-      .uart_rts      (),
-      .uart_cts      (1'b1)
+      .UART0_txd      (uart_txd),
+      .UART0_rxd      (uart_rxd),
+      .UART0_rts      (),
+      .UART0_cts      (1'b1)
       );
 
 endmodule

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -56,13 +56,7 @@ HEXPROGS=boot.hex firmware.hex
 
 # make system.v with peripherals
 system.v: $(SRC_DIR)/system_core.v
-	cp $< $@
-	$(foreach p, $(PERIPHERALS), $(eval HFILES=$(shell echo `ls $($p_DIR)/hardware/include/*.vh | grep -v pio | grep -v inst | grep -v swreg`)) \
-	$(eval HFILES+=$(notdir $(filter %swreg_def.vh, $(VHDR)))) \
-	$(if $(HFILES), $(foreach f, $(HFILES), sed -i '/PHEADER/a `include \"$f\"' $@;),)) # insert header files
-	$(foreach p, $(PERIPHERALS), if test -f $($p_DIR)/hardware/include/pio.vh; then sed -i '/PIO/r $($p_DIR)/hardware/include/pio.vh' $@; fi;) #insert system IOs for peripheral
-	$(foreach p, $(PERIPHERALS), if test -f $($p_DIR)/hardware/include/inst.vh; then sed -i '/endmodule/e cat $($p_DIR)/hardware/include/inst.vh' $@; fi;) # insert peripheral instances
-
+	$(SW_DIR)/python/createSystem.py $(ROOT_DIR) "$(GET_DIRS)" "$(PERIPHERALS)"
 
 # make and copy memory init files
 PYTHON_DIR=$(MEM_DIR)/software/python

--- a/hardware/simulation/simulation.mk
+++ b/hardware/simulation/simulation.mk
@@ -89,19 +89,11 @@ endif
 #
 
 system_tb.v:
-	cp $(TB_DIR)/system_core_tb.v $@
-	$(if $(HFILES), $(foreach f, $(HFILES), sed -i '/PHEADER/a `include \"$f\"' $@;),) # insert header files
+	$(SW_DIR)/python/createTestbench.py $(ROOT_DIR) "$(GET_DIRS)" "$(PERIPHERALS)"
 
 #create  simulation top module
 system_top.v: $(TB_DIR)/system_top_core.v
-	cp $< $@
-	$(foreach p, $(PERIPHERALS), $(eval HFILES=$(shell echo `ls $($p_DIR)/hardware/include/*.vh | grep -v pio | grep -v inst | grep -v swreg`)) \
-	$(eval HFILES+=$(notdir $(filter %swreg_def.vh, $(VHDR)))) \
-	$(if $(HFILES), $(foreach f, $(HFILES), sed -i '/PHEADER/a `include \"$f\"' $@;),)) # insert header files
-	$(foreach p, $(PERIPHERALS), if test -f $($p_DIR)/hardware/include/pio.vh; then sed s/input/wire/ $($p_DIR)/hardware/include/pio.vh | sed s/output/wire/  | sed s/\,/\;/ > wires_tb.vh; sed -i '/PWIRES/r wires_tb.vh' $@; fi;) # declare and insert wire declarations
-	$(foreach p, $(PERIPHERALS), if test -f $($p_DIR)/hardware/include/pio.vh; then sed s/input// $($p_DIR)/hardware/include/pio.vh | sed s/output// | sed 's/\[.*\]//' | sed 's/\([A-Za-z].*\),/\.\1(\1),/' > ./ports.vh; sed -i '/PORTS/r ports.vh' $@; fi;) #insert and connect pins in uut instance
-	$(foreach p, $(PERIPHERALS), if test -f $($p_DIR)/hardware/include/inst_tb.vh; then sed -i '/endmodule/e cat $($p_DIR)/hardware/include/inst_tb.vh' $@; fi;) # insert peripheral instances
-
+	$(SW_DIR)/python/createTopSystem.py $(ROOT_DIR) "$(GET_DIRS)" "$(PERIPHERALS)"
 
 #add peripheral testbench sources
 VSRC+=$(foreach p, $(PERIPHERALS), $(shell if test -f $($p_DIR)/hardware/testbench/module_tb.sv; then echo $($p_DIR)/hardware/testbench/module_tb.sv; fi;)) 

--- a/hardware/simulation/verilog_tb/system_top_core.v
+++ b/hardware/simulation/verilog_tb/system_top_core.v
@@ -231,6 +231,26 @@ module system_top (
          //$finish;
       end
     */
+
+	//Manually added testbench uart core. RS232 pins attached to the same pins
+	//of the uut UART0 instance to communicate with it
+   iob_uart uart_tb
+     (
+      .clk       (clk),
+      .rst       (reset),
+      
+      .valid     (uart_valid),
+      .address   (uart_addr),
+      .wdata     (uart_wdata),
+      .wstrb     (uart_wstrb),
+      .rdata     (uart_rdata),
+      .ready     (uart_ready),
+      
+      .txd       (UART0_rxd),
+      .rxd       (UART0_txd),
+      .rts       (UART0_cts),
+      .cts       (UART0_rts)
+      );
    
    
 endmodule

--- a/hardware/src/boot_ctr.v
+++ b/hardware/src/boot_ctr.v
@@ -3,6 +3,9 @@
 `include "iob_intercon.vh"
 
 module boot_ctr
+  #(
+    parameter HEXFILE = "boot.hex"
+ )
   (
    input                      clk,
    input                      rst,
@@ -108,7 +111,7 @@ module boot_ctr
      #(
        .DATA_W(`DATA_W),
        .ADDR_W(`BOOTROM_ADDR_W-2),
-       .HEXFILE("boot.hex")
+       .HEXFILE(HEXFILE)
        )
    sp_rom0 (
             .clk(clk),

--- a/hardware/src/int_mem.v
+++ b/hardware/src/int_mem.v
@@ -5,7 +5,9 @@
 module int_mem
   #(
     parameter ADDR_W=32,
-    parameter DATA_W=32
+    parameter DATA_W=32,
+    parameter HEXFILE = "firmware",
+    parameter BOOT_HEXFILE = "boot"
     )
    (
     input                clk,
@@ -69,7 +71,9 @@ module int_mem
    wire [`REQ_W-1:0]     ram_w_req;
    wire [`RESP_W-1:0]    ram_w_resp;
 
-   boot_ctr boot_ctr0 
+   boot_ctr 
+        #(.HEXFILE({BOOT_HEXFILE,".hex"}))
+	boot_ctr0 
        (
         .clk(clk),
         .rst(rst),
@@ -151,7 +155,7 @@ module int_mem
    //
    sram
 `ifdef SRAM_INIT
-        #(.HEXFILE("firmware"))
+        #(.HEXFILE(HEXFILE))
 `endif
    int_sram 
      (

--- a/software/bootloader/boot.c
+++ b/software/bootloader/boot.c
@@ -7,7 +7,7 @@
 
 //defined here (and not in periphs.h) because it is the only peripheral used
 //by the bootloader
-#define UART_BASE (1<<P) |(UART<<(ADDR_W-2-N_SLAVES_W))
+#define UART_BASE (1<<P) |(UART0<<(P-N_SLAVES_W))
 
 #define PROGNAME "IOb-Bootloader"
 

--- a/software/firmware/Makefile
+++ b/software/firmware/Makefile
@@ -9,6 +9,10 @@ ifeq ($(USE_DDR),1)
 include $(CACHE_DIR)/software/software.mk
 endif
 
+#
+# ADD SUBMODULES SOFTWARE
+#
+
 #uart
 include $(UART_DIR)/software/embedded/embedded.mk
 

--- a/software/firmware/firmware.c
+++ b/software/firmware/firmware.c
@@ -7,7 +7,7 @@
 int main()
 {
   //init uart
-  uart_init(UART_BASE,FREQ/BAUD);   
+  uart_init(UART0_BASE,FREQ/BAUD);   
   uart_puts("\n\n\nHello world!\n\n\n");
   printf("Value of Pi = %f\n\n", 3.1415);
   uart_finish();

--- a/software/pc-emul/Makefile
+++ b/software/pc-emul/Makefile
@@ -8,8 +8,12 @@ CFLAGS=-Os -std=gnu99 -Wl,--strip-debug
 #DEFINE+=-DLONGLONG
 DEFINE+=-DPC
 
-#peripherals (pc)
-$(foreach p, $(PERIPHERALS), $(eval include $($p_DIR)/software/pc-emul/pc-emul.mk))
+#
+# ADD SUBMODULES PC-EMUL
+#
+
+#uart
+include $(UART_DIR)/software/pc-emul/pc-emul.mk
 
 #HEADERS
 HDR+=periphs.h

--- a/software/python/createSystem.py
+++ b/software/python/createSystem.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+#Creates system.v based on system_core.v template 
+
+import sys, os
+
+# Add folder to path that contains python scripts to be imported
+import submodule_utils 
+from submodule_utils import *
+
+# Signals in this template will only be inserted if they exist in the peripheral IO
+reserved_signals_template = """\
+      .clk(clk),
+      .rst(reset),
+      .arst(reset),
+      .valid(slaves_req[`valid(`/*<InstanceName>*/)]),
+      .address(slaves_req[`address(`/*<InstanceName>*/,`/*<SwregFilename>*/_ADDR_W+2)-2]),
+      .wdata(slaves_req[`wdata(`/*<InstanceName>*/)]),
+      .wstrb(slaves_req[`wstrb(`/*<InstanceName>*/)]),
+      .rdata(slaves_resp[`rdata(`/*<InstanceName>*/)]),
+      .ready(slaves_resp[`ready(`/*<InstanceName>*/)]),
+"""
+
+def create_systemv(directories_str, peripherals_str):
+    # Get peripherals, directories and signals
+    instances_amount = get_peripherals(peripherals_str)
+    submodule_directories = get_submodule_directories(directories_str)
+    peripheral_signals = get_peripherals_signals(instances_amount, submodule_directories)
+
+    # Read template file
+    template_file = open(root_dir+"/hardware/src/system_core.v", "r")
+    template_contents = template_file.readlines() 
+    template_file.close()
+
+    for corename in instances_amount:
+        # Insert header files
+        path = root_dir+"/"+submodule_directories[corename]+"/hardware/include"
+        start_index = find_idx(template_contents, "PHEADER")
+        for file in os.listdir(path):
+            if file.endswith(".vh") and not any(x in file for x in ["pio","inst","swreg"]):
+                template_contents.insert(start_index, '`include "{}"\n'.format(path+"/"+file))
+            if file.endswith("swreg.vh"):
+                template_contents.insert(start_index, '`include "{}"\n'.format(file.replace("swreg","swreg_def")))
+
+        swreg_filename = get_top_module(root_dir+"/"+submodule_directories[corename]+"/config.mk")+"_swreg";
+
+        # Insert IOs and Instances for this type of peripheral
+        for i in range(instances_amount[corename]):
+            pio_signals = get_pio_signals(peripheral_signals[corename])
+            # Insert system IOs for peripheral
+            start_index = find_idx(template_contents, "PIO")
+            for signal in pio_signals:
+                template_contents.insert(start_index, '    {} {}_{},\n'.format(peripheral_signals[corename][signal].replace("/*<SwregFilename>*/",swreg_filename),corename+str(i),signal))
+            # Insert peripheral instance
+            start_index = find_idx(template_contents, "endmodule")-1
+            template_contents.insert(start_index, "      );\n")
+            first_reversed_signal=True
+            # Insert reserved signals 
+            for signal in reversed(reserved_signals_template.splitlines(True)):
+                str_match=re.match("^\s*\.([^\(]+)\(",signal)
+                # Only insert if this reserved signal (from template) is present in IO of this peripheral
+                if (str_match is not None) and str_match.group(1) in peripheral_signals[corename]:
+                    template_contents.insert(start_index, 
+                            re.sub("\/\*<InstanceName>\*\/",corename+str(i),
+                            re.sub("\/\*<SwregFilename>\*\/",swreg_filename, 
+                                signal)))
+                    # Remove comma at the end of last signal
+                    if first_reversed_signal == True:
+                        template_contents[start_index]=template_contents[start_index][::-1].replace(",","",1)[::-1]
+                        first_reversed_signal = False
+            # Insert io signals
+            for signal in pio_signals:
+                template_contents.insert(start_index, '      .{}({}_{}),\n'.format(signal,corename+str(i),signal))
+            template_contents.insert(start_index, "     (\n")
+            template_contents.insert(start_index, "   {} {}\n".format(swreg_filename[:-6], corename+str(i)))
+            template_contents.insert(start_index, "\n")
+            template_contents.insert(start_index, "   // {}\n".format(corename+str(i)))
+            template_contents.insert(start_index, "\n")
+
+    # Write system.v
+    systemv_file = open("system.v", "w")
+    systemv_file.writelines(template_contents)
+    systemv_file.close()
+
+
+if __name__ == "__main__":
+    # Parse arguments
+    if len(sys.argv)<4:
+        print("Usage: {} <root_dir> <directories_defined_in_config.mk> <peripherals>\n".format(sys.argv[0]))
+        exit(-1)
+    root_dir=sys.argv[1]
+    submodule_utils.root_dir = root_dir
+
+    create_systemv(sys.argv[2], sys.argv[3]) 

--- a/software/python/createTestbench.py
+++ b/software/python/createTestbench.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+#Creates system_tb.v based on system_core_tb.v template 
+
+import sys, os
+
+# Add folder to path that contains python scripts to be imported
+import submodule_utils 
+from submodule_utils import *
+
+def create_system_testbench(directories_str, peripherals_str):
+    # Get peripherals, directories and signals
+    instances_amount = get_peripherals(peripherals_str)
+    submodule_directories = get_submodule_directories(directories_str)
+    peripheral_signals = get_peripherals_signals(instances_amount, submodule_directories)
+
+    # Read template file
+    template_file = open(root_dir+"/hardware/simulation/verilog_tb/system_core_tb.v", "r")
+    template_contents = template_file.readlines() 
+    template_file.close()
+
+    # Insert header files
+    for corename in instances_amount:
+        path = root_dir+"/"+submodule_directories[corename]+"/hardware/include"
+        start_index = find_idx(template_contents, "PHEADER")
+        for file in os.listdir(path):
+            if file.endswith(".vh") and not any(x in file for x in ["pio","inst","swreg"]):
+                template_contents.insert(start_index, '`include "{}"\n'.format(path+"/"+file))
+            if file.endswith("swreg.vh"):
+                template_contents.insert(start_index, '`include "{}"\n'.format(file.replace("swreg","swreg_def")))
+
+    # Write system.v
+    systemv_file = open("system_tb.v", "w")
+    systemv_file.writelines(template_contents)
+    systemv_file.close()
+
+
+if __name__ == "__main__":
+    # Parse arguments
+    if len(sys.argv)<4:
+        print("Usage: {} <root_dir> <directories_defined_in_config.mk> <peripherals>\n".format(sys.argv[0]))
+        exit(-1)
+    root_dir=sys.argv[1]
+    submodule_utils.root_dir = root_dir
+    create_system_testbench(sys.argv[2], sys.argv[3]) 

--- a/software/python/createTopSystem.py
+++ b/software/python/createTopSystem.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+#Creates system_top.v based on system_top_core.v template 
+
+import sys, os
+
+# Add folder to path that contains python scripts to be imported
+import submodule_utils 
+from submodule_utils import *
+
+def create_top_system(directories_str, peripherals_str):
+    # Get peripherals, directories and signals
+    instances_amount = get_peripherals(peripherals_str)
+    submodule_directories = get_submodule_directories(directories_str)
+    peripheral_signals = get_peripherals_signals(instances_amount, submodule_directories)
+
+    # Read template file
+    template_file = open(root_dir+"/hardware/simulation/verilog_tb/system_top_core.v", "r")
+    template_contents = template_file.readlines() 
+    template_file.close()
+
+    # Insert header files
+    for corename in instances_amount:
+        path = root_dir+"/"+submodule_directories[corename]+"/hardware/include"
+        start_index = find_idx(template_contents, "PHEADER")
+        for file in os.listdir(path):
+            if file.endswith(".vh") and not any(x in file for x in ["pio","inst","swreg"]):
+                template_contents.insert(start_index, '`include "{}"\n'.format(path+"/"+file))
+            if file.endswith("swreg.vh"):
+                template_contents.insert(start_index, '`include "{}"\n'.format(file.replace("swreg","swreg_def")))
+
+        swreg_filename = get_top_module(root_dir+"/"+submodule_directories[corename]+"/config.mk")+"_swreg";
+
+        # Insert wires and connect them to uut 
+        for i in range(instances_amount[corename]):
+            pio_signals = get_pio_signals(peripheral_signals[corename])
+            # Insert system IOs for peripheral
+            start_index = find_idx(template_contents, "PWIRES")
+            for signal in pio_signals:
+                template_contents.insert(start_index, '   {}  {}_{};\n'.format(re.sub("(?:(?:input)|(?:output))\s+","wire ",peripheral_signals[corename][signal].replace("/*<SwregFilename>*/",swreg_filename)),corename+str(i),signal))
+            # Connect wires to soc port
+            start_index = find_idx(template_contents, "PORTS")
+            for signal in pio_signals:
+                template_contents.insert(start_index, '               .{signal}({signal}),\n'.format(signal=corename+str(i)+"_"+signal))
+
+    # Write system.v
+    systemv_file = open("system_top.v", "w")
+    systemv_file.writelines(template_contents)
+    systemv_file.close()
+
+
+if __name__ == "__main__":
+    # Parse arguments
+    if len(sys.argv)<4:
+        print("Usage: {} <root_dir> <directories_defined_in_config.mk> <peripherals>\n".format(sys.argv[0]))
+        exit(-1)
+    root_dir=sys.argv[1]
+    submodule_utils.root_dir = root_dir
+    create_top_system(sys.argv[2], sys.argv[3]) 

--- a/software/python/periphs_tmp.py
+++ b/software/python/periphs_tmp.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+#Creates periphs_tmp.h
+
+import sys, os
+
+# Add folder to path that contains python scripts to be imported
+import submodule_utils 
+from submodule_utils import *
+
+# Arguments:
+#   P: $P variable in config.mk
+#   peripheral_instances_amount: list with amount of instances of each peripheral (returned by get_peripherals())
+def create_periphs_tmp(P, peripheral_instances_amount, filename):
+
+    template_contents = []
+    for corename in peripheral_instances_amount:
+        for i in range(peripheral_instances_amount[corename]):
+            template_contents.insert(0,"#define {}_BASE (1<<{}) |({}<<({}-N_SLAVES_W))\n".format(corename+str(i),P,corename+str(i),P))
+
+    # Write system.v
+    periphs_tmp_file = open(filename, "w")
+    periphs_tmp_file.writelines(template_contents)
+    periphs_tmp_file.close()
+
+
+if __name__ == "__main__":
+    # Parse arguments
+    if len(sys.argv)<3:
+        print("Needs two arguments.\nUsage: {} <address_selection_bits_of_peripherals (config.mk variable $P)> <peripherals>".format(sys.argv[0]))
+        exit(-1)
+    create_periphs_tmp(sys.argv[1], get_peripherals(sys.argv[2]), "periphs_tmp.h") 

--- a/software/python/submodule_utils.py
+++ b/software/python/submodule_utils.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# Library with useful functions to manage submodules and peripherals
+
+import sys
+import subprocess
+import os
+import re
+import math
+
+# Parameter: string with directories separated by ';'
+# Returns dictionary with every directory defined in <root_dir>/config.mk
+def get_directories(directories_str):
+    # Get directories for each submodule
+    directories = {}
+    list_dirs_str = directories_str.split(';')
+    list_dirs_str.pop(-1)
+    for line in list_dirs_str:
+        var_name, path  = line.strip().split("=", 1)
+        directories[var_name] = path
+    return directories
+
+# Convert keys from format "CORENAME_DIR" to "CORENAME"
+# (Removes "_DIR" sufix from every key in the directories dictionary)
+def get_submodule_directories(directories_str):
+    directories = get_directories(directories_str)
+    keys = list(directories.keys())
+    for key in keys:
+        directories[key.replace("_DIR","")] = directories.pop(key)
+    return directories
+
+# Parameter: PERIPHERALS string defined in config.mk
+# Returns dictionary with amount of instances each peripheral of the SoC to be created 
+def get_peripherals(peripherals_str):
+    peripherals = peripherals_str.split()
+
+    # Count how many instances to create of each type of peripheral
+    instances_amount = {}
+    for i in peripherals:
+        instances_amount[i]=peripherals.count(i)
+
+    return instances_amount
+
+# Given lines read from the verilog file with a module declaration
+# this function returns the inputs and outputs defined in the port list
+# of that module. The return value is a dictionary, where the key is the 
+# signal name and the value is a string like "input [10:0]"
+def get_module_io(verilog_lines):
+    module_start = 0
+    #Find module declaration
+    for line in verilog_lines:
+        module_start += 1
+        if "module " in line:
+            break #Found module declaration
+
+    port_list_start = module_start
+    #Find module port list start 
+    for i in range(module_start, len(verilog_lines)):
+        port_list_start += 1
+        if verilog_lines[i].replace(" ", "").startswith("("):
+            break #Found port list start
+
+    module_signals = {}
+    #Get signals of this module
+    for i in range(port_list_start, len(verilog_lines)):
+        #Ignore comments and empty lines
+        if not verilog_lines[i].strip() or verilog_lines[i].lstrip().startswith("//"):
+            continue
+        if ");" in verilog_lines[i]:
+            break #Found end of port list
+        #If this signal is declared in normal verilog format (no macros)
+        if any(verilog_lines[i].lstrip().startswith(x) for x in ["input","output"]):
+            signal = re.search("^\s*((?:input)|(?:output))(?:\s|(?:\[([^:]+):([^\]]+)\]))*(.*),?", verilog_lines[i])
+            if signal is not None:
+                # Store signal in dictionary with format: module_signals[signalname] = "input [size:0]"
+                if signal.group(2) is None:
+                    module_signals[signal.group(4)]=signal.group(1)
+                else:
+                    #FUTURE IMPROVEMENT: make python parse verilog macros.
+                    module_signals[signal.group(4)]="{} [{}:{}]".format(signal.group(1), 
+                            signal.group(2) if signal.group(2).isdigit() else
+                            ("" if "`" in signal.group(2) else "`") # Set as macro if it was a parameter
+                            +signal.group(2).replace("ADDR_W","/*<SwregFilename>*/_ADDR_W"),
+                            signal.group(3))
+        elif "`IOB_INPUT" in verilog_lines[i]: #If it is a known verilog macro
+            signal = re.search("^\s*`IOB_INPUT\(\s*(\w+)\s*,\s*([^\s]+)\s*\),?", verilog_lines[i])
+            if signal is not None:
+                # Store signal in dictionary with format: module_signals[signalname] = "input [size:0]"
+                module_signals[signal.group(1)]="input [{}:0]".format(
+                        int(signal.group(2))-1 if signal.group(2).isdigit() else 
+                        (("" if "`" in signal.group(2) else "`") # Set as macro if it was a parameter
+                        +signal.group(2)+"-1").replace("ADDR_W","/*<SwregFilename>*/_ADDR_W")) # Replace keyword "ADDR_W" by "/*<SwregFilename>*/_ADDR_W"
+        elif "`IOB_OUTPUT" in verilog_lines[i]: #If it is a known verilog macro
+            signal = re.search("^\s*`IOB_OUTPUT\(\s*(\w+)\s*,\s*([^\s]+)\s*\),?", verilog_lines[i])
+            if signal is not None:
+                # Store signal in dictionary with format: module_signals[signalname] = "output [size:0]"
+                module_signals[signal.group(1)]="output [{}:0]".format(
+                        int(signal.group(2))-1 if signal.group(2).isdigit() else 
+                        (("" if "`" in signal.group(2) else "`")
+                        +signal.group(2)+"-1").replace("ADDR_W","/*<SwregFilename>*/_ADDR_W")) # Replace keyword "ADDR_W" by "/*<SwregFilename>*/_ADDR_W"
+        elif '`include "gen_if.vh"' in verilog_lines[i]: #If it is a known verilog include
+            module_signals["clk"]="input "
+            module_signals["rst"]="input "
+        elif '`include "iob_s_if.vh"' in verilog_lines[i]: #If it is a known verilog include
+            module_signals["valid"]="input "
+            module_signals["address"]="input [/*<SwregFilename>*/_ADDR_W:0] "
+            module_signals["wdata"]="input [DATA_W:0] "
+            module_signals["wstrb"]="input [DATA_W/8:0] "
+            module_signals["rdata"]="output [DATA_W:0] "
+            module_signals["ready"]="output "
+        else:
+            print("Unknow macro/signal declaration '{}' in module '{}'".format(verilog_lines[i],verilog_lines[module_start-1]))
+            exit(-1)
+    return module_signals
+
+# Given a dictionary of signals, returns a dictionary with only pio signals.
+# It removes reserved signals, such as: clk, rst, valid, address, wdata, wstrb, rdata or ready
+def get_pio_signals(peripheral_signals):
+    pio_signals = peripheral_signals.copy()
+    for signal in ["clk","rst","arst","valid","address","wdata","wstrb","rdata","ready"]:
+        if signal in pio_signals: pio_signals.pop(signal)
+    return pio_signals
+
+# Given a path to a file containing the TOP_MODULE makefile variable declaration, return the value of that variable.
+def get_top_module(file_path):
+    config_file = open(file_path, "r")
+    config_contents = config_file.readlines()
+    config_file.close()
+    top_module = ""
+    for line in config_contents:
+        top_module_search = re.search("^\s*TOP_MODULE\s*:?\??=\s*([^\s]+)", line)
+        if top_module_search is not None:
+            top_module = top_module_search.group(1)
+            break;
+    return top_module
+
+# Return dictionary with signals for each peripheral given in the input list 
+# Also need to provide a dictionary with directory location of each peripheral given
+def get_peripherals_signals(list_of_peripherals, submodule_directories):
+    # Get signals of each peripheral
+    peripheral_signals = {}
+    for i in list_of_peripherals:
+        peripheral_signals[i] = {}
+        # Find top module verilog file of peripheral
+        module_dir = root_dir+"/"+submodule_directories[i]+"/hardware/src"
+        module_filename = get_top_module(root_dir+"/"+submodule_directories[i]+"/config.mk")+".v";
+        module_path=os.path.join(module_dir,module_filename)
+        # Skip iteration if peripheral does not have top module
+        if not os.path.isfile(module_path):
+            continue
+        # Read file
+        module_file = open(module_path, "r")
+        module_contents = module_file.read().splitlines()
+        # Get module inputs and outputs
+        peripheral_signals[i] = get_module_io(module_contents)
+        
+        module_file.close()
+    #print(peripheral_signals) #DEBUG
+    return peripheral_signals
+
+# Find index of word in array with multiple strings
+def find_idx(lines, word):
+    for idx, i in enumerate(lines):
+        if word in i:
+            break
+    return idx+1
+
+##########################################################
+# Functions to run when this script gets called directly #
+##########################################################
+def print_instances(peripherals_str):
+    instances_amount = get_peripherals(peripherals_str)
+    for corename in instances_amount:
+        for i in range(instances_amount[corename]):
+            print(corename+str(i), end=" ")
+
+def print_peripherals(peripherals_str):
+    instances_amount = get_peripherals(peripherals_str)
+    for i in instances_amount:
+        print(i, end=" ")
+
+def print_nslaves(peripherals_str):
+    instances_amount = get_peripherals(peripherals_str)
+    i=0
+    # Calculate total amount of instances
+    for corename in instances_amount:
+        i=i+instances_amount[corename]
+    print(i, end="")
+
+def print_nslaves_w(peripherals_str):
+    instances_amount = get_peripherals(peripherals_str)
+    i=0
+    # Calculate total amount of instances
+    for corename in instances_amount:
+        i=i+instances_amount[corename]
+    print(math.ceil(math.log(i,2)))
+
+#Creates list of defines of peripheral instances with sequential numbers
+def print_peripheral_defines(defmacro, peripherals_str):
+    instances_amount = get_peripherals(peripherals_str)
+    j=0
+    for corename in instances_amount:
+        for i in range(instances_amount[corename]):
+            print(defmacro+corename+str(i)+"="+str(j), end=" ")
+            j = j + 1
+
+if __name__ == "__main__":
+    # Parse arguments
+    if sys.argv[1] == "get_peripherals":
+        if len(sys.argv)<3:
+            print("Usage: {} get_peripherals <peripherals>\n".format(sys.argv[0]))
+            exit(-1)
+        print_peripherals(sys.argv[2])
+    elif sys.argv[1] == "get_instances":
+        if len(sys.argv)<3:
+            print("Usage: {} get_instances <peripherals>\n".format(sys.argv[0]))
+            exit(-1)
+        print_instances(sys.argv[2])
+    elif sys.argv[1] == "get_n_slaves":
+        if len(sys.argv)<3:
+            print("Usage: {} get_n_slaves <peripherals>\n".format(sys.argv[0]))
+            exit(-1)
+        print_nslaves(sys.argv[2])
+    elif sys.argv[1] == "get_n_slaves_w":
+        if len(sys.argv)<3:
+            print("Usage: {} get_n_slaves_w <peripherals>\n".format(sys.argv[0]))
+            exit(-1)
+        print_nslaves_w(sys.argv[2])
+    elif sys.argv[1] == "get_defines":
+        if len(sys.argv)<3:
+            print("Usage: {} get_defines <peripherals> <optional:defmacro>\n".format(sys.argv[0]))
+            exit(-1)
+        if len(sys.argv)<4:
+            print_peripheral_defines("",sys.argv[2])
+        else:
+            print_peripheral_defines(sys.argv[3],sys.argv[2])
+    else:
+        print("Unknown command.\nUsage: {} <command> <parameters>\n Commands: get_peripherals get_instances get_n_slaves get_n_slaves_w get_defines print_peripheral_defines".format(sys.argv[0]))
+        exit(-1)

--- a/software/software.mk
+++ b/software/software.mk
@@ -41,7 +41,7 @@ periphs.h: periphs_tmp.h
 	@rm periphs_tmp.h
 
 periphs_tmp.h:
-	$(foreach p, $(PERIPHERALS), $(shell echo "#define $p_BASE (1<<$P) |($p<<($P-N_SLAVES_W))" >> $@) )
+	$(SW_DIR)/python/periphs_tmp.py $P "$(PERIPHERALS)"
 
 build-all:
 	make -C $(FIRM_DIR) build


### PR DESCRIPTION
Replaced system build scripts previously in bash, by a python3 version
that allows for multiple instances of the same peripheral type (with
the same corename).
To add multiple instances of the same peripheral, add the corename of
that peripheral multiple times to the PERIPHERALS list in the config.mk
file.
For example, to have 2 UART instances, use the following PERIPHERALS list:
`PERIPHERALS ?=UART UART`
This list will create two instances named: UART0 and UART1

This new python3 based build process no longer uses the 'pio.vh' and
'inst.vh' files inside each peripheral. The signals from these files
are now taken directly from the port list of the verilog top module
for each peripheral.