### PR TITLE
feat(actions): Add workflow concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ defaults:
   run:
     shell: bash -ieo pipefail {0}
 
+# Run only one instance of this workflow at a time
+# cancel-in-progress: stop running workflow and run latest instead
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
- Add concurrency group to guarantee only one instance of workflow-ref
  combination running at a time
- workflows with same ref are canceled and run latest version (for
  example a PR workflow starts running and on more recent commits, the
  workflow is cancelled and starts running the workflow for the latest
  commits)