### PR TITLE
feat(diff): Print difference for test.expected

### DIFF
--- a/document/document.mk
+++ b/document/document.mk
@@ -18,7 +18,7 @@ SWREGS=0
 include $(LIB_DIR)/document/document.mk
 
 test: clean-all $(DOC).pdf
-	diff -q $(DOC).aux test.expected
+	diff $(DOC).aux test.expected
 
 clean-all: clean
 	rm -f $(DOC).pdf

--- a/hardware/fpga/fpga.mk
+++ b/hardware/fpga/fpga.mk
@@ -100,7 +100,7 @@ endif
 #
 
 test: clean-testlog test1 test2 test3
-	diff -q test.log test.expected
+	diff test.log test.expected
 
 test1:
 	make -C $(ROOT_DIR) fpga-clean

--- a/hardware/simulation/simulation.mk
+++ b/hardware/simulation/simulation.mk
@@ -114,7 +114,7 @@ kill-sim:
 
 
 test: clean-testlog test1 test2 test3 test4 test5
-	diff -q test.log ../test.expected
+	diff test.log ../test.expected
 
 test1:
 	make -C $(ROOT_DIR) sim-clean

--- a/software/pc-emul/Makefile
+++ b/software/pc-emul/Makefile
@@ -37,6 +37,6 @@ clean:
 
 test:
 	make run TEST_LOG="> test.log"
-	sleep 1; diff -q $(PC_DIR)/test.log $(PC_DIR)/test.expected
+	sleep 1; diff $(PC_DIR)/test.log $(PC_DIR)/test.expected
 
 .PHONY: build run clean test


### PR DESCRIPTION
- Remove `-q` (quiet) flag from `diff` command that compares obtained
  log with test.expected logs
- This prints the difference between the files to stdout