### PR TITLE
feat(sw): firmware creates transfered file

### DIFF
--- a/hardware/fpga/fpga.mk
+++ b/hardware/fpga/fpga.mk
@@ -119,7 +119,7 @@ test3:
 #
 
 clean-all: hw-clean
-	@rm -f $(FPGA_OBJ) $(FPGA_LOG)
+	@rm -f $(FPGA_OBJ) $(FPGA_LOG) *.txt
 ifneq ($(FPGA_SERVER),)
 	ssh $(BOARD_USER)@$(BOARD_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"
 	rsync -avz --delete --force --exclude .git $(ROOT_DIR) $(FPGA_USER)@$(FPGA_SERVER):$(REMOTE_ROOT_DIR)

--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/test.expected
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/test.expected
@@ -19,6 +19,19 @@ Hello world!
 
 Value of Pi = 3.141500
 
+IOb-UART: requesting to send file
+IOb-Console: got file receive request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console : file size: 348 bytes
+IOb-Console: file received
+IOb-UART: file sent
+IOb-UART: requesting to receive file
+IOb-Console: got file send request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console: file of size 348 bytes
+IOb-Console: file sent
+IOb-UART: file received
+SUCCESS: Send and received file match!
 IOb-Console: exiting...
 
 +-----------------------------------------------+
@@ -35,14 +48,14 @@ IOb-Bootloader: connected!
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
 IOb-Console: file name b'firmware.bin' 
-IOb-Console: file of size 19048 bytes
+IOb-Console: file of size 19624 bytes
 IOb-Console: file sent
 IOb-UART: file received
 IOb-Bootloader: Loading firmware...
 IOb-UART: requesting to send file
 IOb-Console: got file receive request
 IOb-Console: file name b's_fw.bin' 
-IOb-Console : file size: 19048 bytes
+IOb-Console : file size: 19624 bytes
 IOb-Console: file received
 IOb-UART: file sent
 IOb-Bootloader: Restart CPU to run user program...
@@ -54,4 +67,17 @@ Hello world!
 
 Value of Pi = 3.141500
 
+IOb-UART: requesting to send file
+IOb-Console: got file receive request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console : file size: 348 bytes
+IOb-Console: file received
+IOb-UART: file sent
+IOb-UART: requesting to receive file
+IOb-Console: got file send request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console: file of size 348 bytes
+IOb-Console: file sent
+IOb-UART: file received
+SUCCESS: Send and received file match!
 IOb-Console: exiting...

--- a/hardware/fpga/vivado/AES-KU040-DB-G/test.expected
+++ b/hardware/fpga/vivado/AES-KU040-DB-G/test.expected
@@ -19,6 +19,19 @@ Hello world!
 
 Value of Pi = 3.141500
 
+IOb-UART: requesting to send file
+IOb-Console: got file receive request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console : file size: 348 bytes
+IOb-Console: file received
+IOb-UART: file sent
+IOb-UART: requesting to receive file
+IOb-Console: got file send request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console: file of size 348 bytes
+IOb-Console: file sent
+IOb-UART: file received
+SUCCESS: Send and received file match!
 IOb-Console: exiting...
 
 +-----------------------------------------------+
@@ -35,14 +48,14 @@ IOb-Bootloader: connected!
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
 IOb-Console: file name b'firmware.bin' 
-IOb-Console: file of size 19048 bytes
+IOb-Console: file of size 19624 bytes
 IOb-Console: file sent
 IOb-UART: file received
 IOb-Bootloader: Loading firmware...
 IOb-UART: requesting to send file
 IOb-Console: got file receive request
 IOb-Console: file name b's_fw.bin' 
-IOb-Console : file size: 19048 bytes
+IOb-Console : file size: 19624 bytes
 IOb-Console: file received
 IOb-UART: file sent
 IOb-Bootloader: Restart CPU to run user program...
@@ -54,6 +67,19 @@ Hello world!
 
 Value of Pi = 3.141500
 
+IOb-UART: requesting to send file
+IOb-Console: got file receive request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console : file size: 348 bytes
+IOb-Console: file received
+IOb-UART: file sent
+IOb-UART: requesting to receive file
+IOb-Console: got file send request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console: file of size 348 bytes
+IOb-Console: file sent
+IOb-UART: file received
+SUCCESS: Send and received file match!
 IOb-Console: exiting...
 
 +-----------------------------------------------+
@@ -72,14 +98,14 @@ IOb-Bootloader: program to run from DDR
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
 IOb-Console: file name b'firmware.bin' 
-IOb-Console: file of size 19208 bytes
+IOb-Console: file of size 19784 bytes
 IOb-Console: file sent
 IOb-UART: file received
 IOb-Bootloader: Loading firmware...
 IOb-UART: requesting to send file
 IOb-Console: got file receive request
 IOb-Console: file name b's_fw.bin' 
-IOb-Console : file size: 19208 bytes
+IOb-Console : file size: 19784 bytes
 IOb-Console: file received
 IOb-UART: file sent
 IOb-Bootloader: Restart CPU to run user program...
@@ -91,4 +117,17 @@ Hello world!
 
 Value of Pi = 3.141500
 
+IOb-UART: requesting to send file
+IOb-Console: got file receive request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console : file size: 348 bytes
+IOb-Console: file received
+IOb-UART: file sent
+IOb-UART: requesting to receive file
+IOb-Console: got file send request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console: file of size 348 bytes
+IOb-Console: file sent
+IOb-UART: file received
+FAILURE: Send and received file differ!
 IOb-Console: exiting...

--- a/hardware/simulation/simulation.mk
+++ b/hardware/simulation/simulation.mk
@@ -130,7 +130,7 @@ test5:
 
 #clean target common to all simulators
 clean-remote: hw-clean
-	@rm -f soc2cnsl cnsl2soc
+	@rm -f soc2cnsl cnsl2soc *.txt
 	@rm -f system.vcd
 ifneq ($(SIM_SERVER),)
 	ssh $(SIM_SSH_FLAGS) $(SIM_USER)@$(SIM_SERVER) "if [ ! -d $(REMOTE_ROOT_DIR) ]; then mkdir -p $(REMOTE_ROOT_DIR); fi"

--- a/hardware/simulation/test.expected
+++ b/hardware/simulation/test.expected
@@ -15,10 +15,27 @@ Hello world!
 
 Value of Pi = 3.141500
 
+IOb-UART: requesting to send file
+IOb-Console: got file receive request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console : file size: 348 bytes
+  0 %
+ 10 %
+ 20 %
+ 30 %
+ 40 %
+ 50 %
+ 60 %
+ 70 %
+ 80 %
+ 90 %
+100 %
+IOb-Console: file received
+IOb-UART: file sent
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
-IOb-Console: file name b'Makefile' 
-IOb-Console: file of size 2581 bytes
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console: file of size 348 bytes
   0 %
  10 %
  20 %
@@ -32,6 +49,7 @@ IOb-Console: file of size 2581 bytes
 100 %
 IOb-Console: file sent
 IOb-UART: file received
+SUCCESS: Send and received file match!
 IOb-Console: exiting...
 
 +-----------------------------------------------+
@@ -44,7 +62,7 @@ IOb-Bootloader: connected!
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
 IOb-Console: file name b'firmware.bin' 
-IOb-Console: file of size 19116 bytes
+IOb-Console: file of size 19624 bytes
   0 %
  10 %
  20 %
@@ -62,7 +80,7 @@ IOb-Bootloader: Loading firmware...
 IOb-UART: requesting to send file
 IOb-Console: got file receive request
 IOb-Console: file name b's_fw.bin' 
-IOb-Console : file size: 19116 bytes
+IOb-Console : file size: 19624 bytes
   0 %
  10 %
  20 %
@@ -85,10 +103,27 @@ Hello world!
 
 Value of Pi = 3.141500
 
+IOb-UART: requesting to send file
+IOb-Console: got file receive request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console : file size: 348 bytes
+  0 %
+ 10 %
+ 20 %
+ 30 %
+ 40 %
+ 50 %
+ 60 %
+ 70 %
+ 80 %
+ 90 %
+100 %
+IOb-Console: file received
+IOb-UART: file sent
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
-IOb-Console: file name b'Makefile' 
-IOb-Console: file of size 2581 bytes
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console: file of size 348 bytes
   0 %
  10 %
  20 %
@@ -102,6 +137,7 @@ IOb-Console: file of size 2581 bytes
 100 %
 IOb-Console: file sent
 IOb-UART: file received
+SUCCESS: Send and received file match!
 IOb-Console: exiting...
 
 +-----------------------------------------------+
@@ -121,10 +157,27 @@ Hello world!
 
 Value of Pi = 3.141500
 
+IOb-UART: requesting to send file
+IOb-Console: got file receive request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console : file size: 348 bytes
+  0 %
+ 10 %
+ 20 %
+ 30 %
+ 40 %
+ 50 %
+ 60 %
+ 70 %
+ 80 %
+ 90 %
+100 %
+IOb-Console: file received
+IOb-UART: file sent
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
-IOb-Console: file name b'Makefile' 
-IOb-Console: file of size 2581 bytes
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console: file of size 348 bytes
   0 %
  10 %
  20 %
@@ -138,6 +191,7 @@ IOb-Console: file of size 2581 bytes
 100 %
 IOb-Console: file sent
 IOb-UART: file received
+SUCCESS: Send and received file match!
 IOb-Console: exiting...
 
 +-----------------------------------------------+
@@ -158,10 +212,27 @@ Hello world!
 
 Value of Pi = 3.141500
 
+IOb-UART: requesting to send file
+IOb-Console: got file receive request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console : file size: 348 bytes
+  0 %
+ 10 %
+ 20 %
+ 30 %
+ 40 %
+ 50 %
+ 60 %
+ 70 %
+ 80 %
+ 90 %
+100 %
+IOb-Console: file received
+IOb-UART: file sent
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
-IOb-Console: file name b'Makefile' 
-IOb-Console: file of size 2581 bytes
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console: file of size 348 bytes
   0 %
  10 %
  20 %
@@ -175,6 +246,7 @@ IOb-Console: file of size 2581 bytes
 100 %
 IOb-Console: file sent
 IOb-UART: file received
+SUCCESS: Send and received file match!
 IOb-Console: exiting...
 
 +-----------------------------------------------+
@@ -189,7 +261,7 @@ IOb-Bootloader: program to run from DDR
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
 IOb-Console: file name b'firmware.bin' 
-IOb-Console: file of size 19276 bytes
+IOb-Console: file of size 19784 bytes
   0 %
  10 %
  20 %
@@ -207,7 +279,7 @@ IOb-Bootloader: Loading firmware...
 IOb-UART: requesting to send file
 IOb-Console: got file receive request
 IOb-Console: file name b's_fw.bin' 
-IOb-Console : file size: 19276 bytes
+IOb-Console : file size: 19784 bytes
   0 %
  10 %
  20 %
@@ -230,10 +302,27 @@ Hello world!
 
 Value of Pi = 3.141500
 
+IOb-UART: requesting to send file
+IOb-Console: got file receive request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console : file size: 348 bytes
+  0 %
+ 10 %
+ 20 %
+ 30 %
+ 40 %
+ 50 %
+ 60 %
+ 70 %
+ 80 %
+ 90 %
+100 %
+IOb-Console: file received
+IOb-UART: file sent
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
-IOb-Console: file name b'Makefile' 
-IOb-Console: file of size 2581 bytes
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console: file of size 348 bytes
   0 %
  10 %
  20 %
@@ -247,4 +336,5 @@ IOb-Console: file of size 2581 bytes
 100 %
 IOb-Console: file sent
 IOb-UART: file received
+SUCCESS: Send and received file match!
 IOb-Console: exiting...

--- a/software/pc-emul/Makefile
+++ b/software/pc-emul/Makefile
@@ -34,6 +34,7 @@ run: build
 
 clean: kill-cnsl
 	@rm -rf fw_emul periphs.h *swreg*.h *swreg*.c test.log soc2cnsl cnsl2soc
+	@rm -rf *.txt
 
 test:
 	make run TEST_LOG="> test.log"

--- a/software/pc-emul/test.expected
+++ b/software/pc-emul/test.expected
@@ -13,10 +13,27 @@ Hello world!
 
 Value of Pi = 3.141500
 
+IOb-UART: requesting to send file
+IOb-Console: got file receive request
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console : file size: 348 bytes
+  0 %
+ 10 %
+ 20 %
+ 30 %
+ 40 %
+ 50 %
+ 60 %
+ 70 %
+ 80 %
+ 90 %
+100 %
+IOb-Console: file received
+IOb-UART: file sent
 IOb-UART: requesting to receive file
 IOb-Console: got file send request
-IOb-Console: file name b'Makefile' 
-IOb-Console: file of size 870 bytes
+IOb-Console: file name b'Sendfile.txt' 
+IOb-Console: file of size 348 bytes
   0 %
  10 %
  20 %
@@ -30,4 +47,5 @@ IOb-Console: file of size 870 bytes
 100 %
 IOb-Console: file sent
 IOb-UART: file received
+SUCCESS: Send and received file match!
 IOb-Console: exiting...


### PR DESCRIPTION
- Update firmware to create test file:
  1. firmware sends file to console
  2. afterwards requests the file back
  3. and compares with original sent file
- this avoids using `Makefile` as the transfered file
    - using `Makefile` uses the local `Makefile` which is different for pc-emul, icarus, verilator, Cyclonev and AES-KU040.
    - in particular for the icarus and verilator, using the `Makefile` as the transfered file generates different `test.log` outputs for    each simulator (icarus and verilog makefiles have different sizes). There we can't use the same expected file in `hardware/simulation/test.expected`.
- Update `test.expected` files