### PR TITLE
feat(ci.yml): fix ci.yml syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: setup
         run: make setup
       - name: verilator test
-        run: make -C iob_soc_* sim-test SIMULATOR=verilator
+        run: make -C ../iob_soc_* sim-test SIMULATOR=verilator
   
   icarus:
     runs-on: self-hosted
@@ -70,7 +70,7 @@ jobs:
       - name: setup
         run: make setup
       - name: icarus test
-        run: make -C iob_soc_* sim-test SIMULATOR=icarus
+        run: make -C ../iob_soc_* sim-test SIMULATOR=icarus
   
   # cyclonev:
   #   runs-on: self-hosted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,79 +38,79 @@ jobs:
       - name: pc-emul test
         run: make -C ../iob_soc_* pc-emul-test
 
-   verilator:
-     runs-on: self-hosted
-     timeout-minutes: 30
-     # run even if previous job failed
-     if: ${{ !cancelled() }}
-     # run after indicated job
+  verilator:
+    runs-on: self-hosted
+    timeout-minutes: 30
+    # run even if previous job failed
+    if: ${{ !cancelled() }}
+    # run after indicated job
   
-     steps:
-       - uses: actions/checkout@v3
-         with:
-           submodules: 'recursive'
-       - name: clean
-         run: make clean
-       - name: setup
-         run: make setup
-       - name: verilator test
-         run: make -C iob_soc_* sim-test SIMULATOR=verilator
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: clean
+        run: make clean
+      - name: setup
+        run: make setup
+      - name: verilator test
+        run: make -C iob_soc_* sim-test SIMULATOR=verilator
   
-   icarus:
-     runs-on: self-hosted
-     timeout-minutes: 90
-     if: ${{ !cancelled() }}
+  icarus:
+    runs-on: self-hosted
+    timeout-minutes: 90
+    if: ${{ !cancelled() }}
   
-     steps:
-       - uses: actions/checkout@v3
-         with:
-           submodules: 'recursive'
-       - name: clean
-         run: make clean
-       - name: setup
-         run: make setup
-       - name: icarus test
-         run: make -C iob_soc_* sim-test SIMULATOR=icarus
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+      - name: clean
+        run: make clean
+      - name: setup
+        run: make setup
+      - name: icarus test
+        run: make -C iob_soc_* sim-test SIMULATOR=icarus
   
-   # cyclonev:
-   #   runs-on: self-hosted
-   #   timeout-minutes: 60
-   #   if: ${{ !cancelled() }}
-   #
-   #   steps:
-   #     - uses: actions/checkout@v3
-   #       with:
-   #         submodules: 'recursive'
-   #     - name: test-clean
-   #       run: make test-clean
-   #     - name: test-cyclonev
-   #       run: make fpga-test BOARD=CYCLONEV-GT-DK
-   #
-   # aes-ku040:
-   #   runs-on: self-hosted
-   #   timeout-minutes: 90
-   #   if: ${{ !cancelled() }}
-   #
-   #   steps:
-   #     - uses: actions/checkout@v3
-   #       with:
-   #         submodules: 'recursive'
-   #     - name: test-clean
-   #       run: make test-clean
-   #     - name: test-aes-ku040
-   #       run: make fpga-test BOARD=AES-KU040-DB-G
-   #
-   # doc:
-   #   runs-on: self-hosted
-   #   timeout-minutes: 60
-   #   if: ${{ !cancelled() }}
-   #   needs: [ cyclonev, aes-ku040 ]
-   #
-   #   steps:
-   #     - uses: actions/checkout@v3
-   #       with:
-   #         submodules: 'recursive'
-   #     - name: test-clean
-   #       run: make test-clean
-   #     - name: test-doc
-   #       run: make test-doc
+  # cyclonev:
+  #   runs-on: self-hosted
+  #   timeout-minutes: 60
+  #   if: ${{ !cancelled() }}
+  #
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         submodules: 'recursive'
+  #     - name: test-clean
+  #       run: make test-clean
+  #     - name: test-cyclonev
+  #       run: make fpga-test BOARD=CYCLONEV-GT-DK
+  #
+  # aes-ku040:
+  #   runs-on: self-hosted
+  #   timeout-minutes: 90
+  #   if: ${{ !cancelled() }}
+  #
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         submodules: 'recursive'
+  #     - name: test-clean
+  #       run: make test-clean
+  #     - name: test-aes-ku040
+  #       run: make fpga-test BOARD=AES-KU040-DB-G
+  #
+  # doc:
+  #   runs-on: self-hosted
+  #   timeout-minutes: 60
+  #   if: ${{ !cancelled() }}
+  #   needs: [ cyclonev, aes-ku040 ]
+  #
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         submodules: 'recursive'
+  #     - name: test-clean
+  #       run: make test-clean
+  #     - name: test-doc
+  #       run: make test-doc


### PR DESCRIPTION
- Remove extra space before each line in verilator and icarus jobs