### PR TITLE
feat(setup.py,ci.yml): use nix-shell in ci.yml; update iob_soc_setup.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: setup
         run: make setup
       - name: verilator test
-        run: make -C ../iob_soc_* sim-test SIMULATOR=verilator
+        run: nix-shell -p verilator --run 'make -C ../iob_soc_* sim-test SIMULATOR=verilator'
   
   icarus:
     runs-on: self-hosted

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 setup clean python-cache-clean debug:
 	make -f submodules/LIB/setup.mk $@
 
+clean: python-cache-clean
+
 .PHONY: setup clean debug config 

--- a/hardware/simulation/system_top.vt
+++ b/hardware/simulation/system_top.vt
@@ -47,7 +47,7 @@ module system_top
 
    //AXI wires for connecting system to memory
 
-`ifdef IOB_SOC_RUN_EXTMEM
+`ifdef RUN_EXTMEM
  `include "m_axi_wire.vh"
 `endif
 
@@ -64,7 +64,7 @@ module system_top
    uut
      (
       //PORTS
-`ifdef IOB_SOC_RUN_EXTMEM
+`ifdef RUN_EXTMEM
  `include "m_axi_portmap.vh"
 `endif               
       .clk_i (clk_i),
@@ -74,7 +74,7 @@ module system_top
 
 
    //instantiate the axi memory
-`ifdef IOB_SOC_RUN_EXTMEM
+`ifdef RUN_EXTMEM
    axi_ram 
      #(
  `ifdef DDR_INIT

--- a/hardware/src/ext_mem.v
+++ b/hardware/src/ext_mem.v
@@ -17,11 +17,9 @@ module ext_mem
     parameter AXI_DATA_W=`IOB_SOC_AXI_DATA_W
     )
    (
-`ifdef IOB_SOC_RUN_EXTMEM
     // Instruction bus
     input [1+FIRM_ADDR_W-2+`WRITE_W-1:0]     i_req,
     output [`RESP_W-1:0] 		      i_resp,
-`endif
 
     // Data bus
     input [1+1+DCACHE_ADDR_W-2+`WRITE_W-1:0] d_req,
@@ -33,7 +31,6 @@ module ext_mem
 	input [1-1:0] rst_i //reset  asynchronous and active high.
     );
 
-`ifdef IOB_SOC_RUN_EXTMEM
    //
    // INSTRUCTION CACHE
    //
@@ -80,7 +77,6 @@ module ext_mem
       .be_rdata (icache_be_resp[`rdata(0)]),
       .be_ack (icache_be_resp[`rvalid(0)])
       );
-`endif //  `ifdef RUN_EXTMEM
 
    //l2 cache interface signals
    wire [1+DCACHE_ADDR_W+`WRITE_W-1:0]       l2cache_req;
@@ -153,24 +149,15 @@ module ext_mem
    iob_merge
      #(
        .ADDR_W(DCACHE_ADDR_W),
-`ifdef IOB_SOC_RUN_EXTMEM
        .N_MASTERS(2)
-`else
-       .N_MASTERS(1)
-`endif
        )
    merge_i_d_buses_into_l2
      (
       .clk_i(clk_i),
       .rst_i(rst_i),
       // masters
-`ifdef IOB_SOC_RUN_EXTMEM
       .m_req_i  ({icache_be_req, dcache_be_req}),
-      .m_resp_o ({icache_be_resp, dcache_be_resp}),
-`else
-      .m_req_i  (dcache_be_req),
-      .m_resp_o (dcache_be_resp),
-`endif                 
+      .m_resp_o ({icache_be_resp, dcache_be_resp}),         
       // slave
       .s_req_o  (l2cache_req),
       .s_resp_i (l2cache_resp)

--- a/hardware/src/int_mem.v
+++ b/hardware/src/int_mem.v
@@ -167,7 +167,7 @@ module int_mem
    //
    sram
         #(
-`ifdef IOB_SOC_INIT_MEM
+`ifdef INIT_MEM
         .HEXFILE(HEXFILE),
 `endif
         .DATA_W(DATA_W),

--- a/hardware/src/system.vt
+++ b/hardware/src/system.vt
@@ -68,7 +68,7 @@ module system
    wire [`REQ_W-1:0]  int_mem_i_req;
    wire [`RESP_W-1:0] int_mem_i_resp;
    //external memory instruction bus
-`ifdef IOB_SOC_RUN_EXTMEM
+`ifdef RUN_EXTMEM
    wire [`REQ_W-1:0]  ext_mem_i_req;
    wire [`RESP_W-1:0] ext_mem_i_resp;
 `endif
@@ -76,7 +76,7 @@ module system
    // INSTRUCTION BUS
    iob_split
      #(
-`ifdef IOB_SOC_RUN_EXTMEM
+`ifdef RUN_EXTMEM
        .N_SLAVES(2),
 `else
        .N_SLAVES(1),
@@ -92,7 +92,7 @@ module system
       .m_resp_o (cpu_i_resp),
       
       // slaves interface
-`ifdef IOB_SOC_RUN_EXTMEM
+`ifdef RUN_EXTMEM
       .s_req_o ( {ext_mem_i_req, int_mem_i_req} ),
       .s_resp_i ( {ext_mem_i_resp, int_mem_i_resp} )
 `else
@@ -104,7 +104,7 @@ module system
 
    // DATA BUS
 
-`ifdef IOB_SOC_RUN_EXTMEM
+`ifdef RUN_EXTMEM
    //external memory data bus
    wire [`REQ_W-1:0]         ext_mem_d_req;
    wire [`RESP_W-1:0]        ext_mem_d_resp;
@@ -153,7 +153,7 @@ module system
       .clk_i (clk_i),
       .rst_i (cpu_reset),
 
-`ifdef IOB_SOC_RUN_EXTMEM
+`ifdef RUN_EXTMEM
       // master interface
       .m_req_i  ( int_d_req  ),
       .m_resp_o ( int_d_resp ),
@@ -225,7 +225,7 @@ module system
       .d_resp (int_mem_d_resp)
       );
 
-`ifdef IOB_SOC_RUN_EXTMEM
+`ifdef RUN_EXTMEM
    //
    // EXTERNAL DDR MEMORY
    //

--- a/iob_soc_setup.py
+++ b/iob_soc_setup.py
@@ -55,12 +55,12 @@ dirs |= {
 confs = \
 [
     # SoC defines
-    {'name':'USE_MUL_DIV',   'type':'D', 'val':'1', 'min':'0', 'max':'1', 'descr':"Enable MUL and DIV CPU instrunctions"},
-    {'name':'USE_COMPRESSED','type':'D', 'val':'1', 'min':'0', 'max':'1', 'descr':"Use compressed CPU instructions"},
     {'name':'INIT_MEM',      'type':'D', 'val':'1', 'min':'0', 'max':'1', 'descr':"Enable memory initialization"},
     {'name':'RUN_EXTMEM',    'type':'D', 'val':'0', 'min':'0', 'max':'1', 'descr':"Run firmware from external memory"}, #This is the new USE_DDR
 
     # SoC macros
+    {'name':'USE_MUL_DIV',   'type':'M', 'val':'1', 'min':'0', 'max':'1', 'descr':"Enable MUL and DIV CPU instrunctions"},
+    {'name':'USE_COMPRESSED','type':'M', 'val':'1', 'min':'0', 'max':'1', 'descr':"Use compressed CPU instructions"},
     {'name':'E',             'type':'M', 'val':'31', 'min':'1', 'max':'32', 'descr':"Address selection bit for external memory"},
     {'name':'P',             'type':'M', 'val':'30', 'min':'1', 'max':'32', 'descr':"Address selection bit for peripherals"},
     {'name':'B',             'type':'M', 'val':'29', 'min':'1', 'max':'32', 'descr':"Address selection bit for boot ROM"},
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     setup_submodule(f"../{meta['name']+'_'+meta['version']}","submodules/CACHE")
     setup_submodule(f"../{meta['name']+'_'+meta['version']}","submodules/PICORV32")
     # Setup this system
-    setup(meta['name'], meta['version'], confs, ios, None, blocks)
+    setup(meta, confs, ios, None, blocks)
     # periphs_tmp.h
     periphs_tmp.create_periphs_tmp(next(i['val'] for i in confs if i['name'] == 'P'),
                                    peripherals_list, f"../{meta['name']+'_'+meta['version']}/software/periphs.h")


### PR DESCRIPTION
- Use nix-shell to run verilator target in ci.yml
- Add configurable main function. This is useful when this system is used as a submodule of another. This allows the main system to configure the setup process of this one.
- Update directories variable. `submodule_dirs` variable now uses uppercase names to match the peripheral corenames/types. Python functions use this dictionary to access the location of peripherals.
- Add python-cache-clean makefile target as dependecy of clean.
- Update submodules