### PR TITLE
Simulation: progress in running simulation with RUN_EXTMEM=1;

### DIFF
--- a/hardware/src/ext_mem.v
+++ b/hardware/src/ext_mem.v
@@ -17,25 +17,28 @@ module ext_mem
     parameter AXI_DATA_W=`IOB_SOC_AXI_DATA_W
   ) (
     // Instruction bus
-    input [1+FIRM_ADDR_W-2+`WRITE_W-1:0]     i_req,
-    output [`RESP_W-1:0] 		      i_resp,
+    input [1+FIRM_ADDR_W-2+`WRITE_W-1:0] i_req,
+    output [`RESP_W-1:0] 		         i_resp,
 
     // Data bus
     input [1+1+DCACHE_ADDR_W-2+`WRITE_W-1:0] d_req,
-    output [`RESP_W-1:0] 		      d_resp,
+    output [`RESP_W-1:0] 		             d_resp,
 
     // AXI interface 
     `include "iob_axi_m_port.vh"
     `include "iob_clkrst_port.vh"
   );
 
+    //assign d_resp[`rvalid(0)] = d_resp[`ready(0)];
+    //assign i_resp[`rvalid(0)] = i_resp[`ready(0)];
+
    //
    // INSTRUCTION CACHE
    //
 
    // Back-end bus
-   wire [1+DCACHE_ADDR_W+`WRITE_W-1:0]       icache_be_req;
-   wire [`RESP_W-1:0] 			      icache_be_resp;
+   wire [1+DCACHE_ADDR_W+`WRITE_W-1:0] icache_be_req;
+   wire [`RESP_W-1:0] 			       icache_be_resp;
 
 
    // Instruction cache instance
@@ -61,7 +64,7 @@ module ext_mem
       .wdata (i_req[`wdata(0)]),
       .wstrb (i_req[`wstrb(0)]),
       .rdata (i_resp[`rdata(0)]),
-      .ack (i_resp[`rvalid(0)]),
+      .ack (i_resp[`ready(0)]),
       //Control IO
       .invalidate_in(1'b0),
       .invalidate_out(),
@@ -73,12 +76,12 @@ module ext_mem
       .be_wdata (icache_be_req[`wdata(0)]),
       .be_wstrb (icache_be_req[`wstrb(0)]),
       .be_rdata (icache_be_resp[`rdata(0)]),
-      .be_ack (icache_be_resp[`rvalid(0)])
+      .be_ack (icache_be_resp[`ready(0)])
       );
 
    //l2 cache interface signals
-   wire [1+DCACHE_ADDR_W+`WRITE_W-1:0]       l2cache_req;
-   wire [`RESP_W-1:0] 			      l2cache_resp;
+   wire [1+DCACHE_ADDR_W+`WRITE_W-1:0] l2cache_req;
+   wire [`RESP_W-1:0] 			       l2cache_resp;
    
    //ext_mem control signals
    wire                                       l2_wtb_empty;
@@ -128,7 +131,7 @@ module ext_mem
       .wdata (d_req[`wdata(0)]),
       .wstrb (d_req[`wstrb(0)]),
       .rdata (d_resp[`rdata(0)]),
-      .ack (d_resp[`rvalid(0)]),
+      .ack (d_resp[`ready(0)]),
       //Control IO
       .invalidate_in(1'b0),
       .invalidate_out(invalidate),
@@ -140,7 +143,7 @@ module ext_mem
       .be_wdata (dcache_be_req[`wdata(0)]),
       .be_wstrb (dcache_be_req[`wstrb(0)]),
       .be_rdata (dcache_be_resp[`rdata(0)]),
-      .be_ack (dcache_be_resp[`rvalid(0)])
+      .be_ack (dcache_be_resp[`ready(0)])
       );
 
    // Merge cache back-ends
@@ -185,7 +188,7 @@ module ext_mem
       .wdata    (l2cache_req[`wdata(0)]),
       .wstrb    (l2cache_req[`wstrb(0)]),
       .rdata    (l2cache_resp[`rdata(0)]),
-      .ack    (l2cache_resp[`rvalid(0)]),
+      .ack    (l2cache_resp[`ready(0)]),
       //Control IO
       .invalidate_in(invalidate_reg & ~l2_avalid),
       .invalidate_out(),

--- a/hardware/src/iob_soc.vt
+++ b/hardware/src/iob_soc.vt
@@ -44,15 +44,13 @@ module system
    wire [`RESP_W-1:0] cpu_d_resp;
    
    //instantiate the cpu
-   iob_picorv32 
-     #(
+   iob_picorv32 #(
        .ADDR_W(ADDR_W),
        .DATA_W(DATA_W),
        .USE_COMPRESSED(`IOB_SOC_USE_COMPRESSED),
        .USE_MUL_DIV(`IOB_SOC_USE_MUL_DIV)
        )
-   cpu
-       (
+   cpu (
         .clk_i (clk_i),
         .rst_i (cpu_reset),
         .cke_i (cke_i),
@@ -83,8 +81,7 @@ module system
 `endif
 
    // INSTRUCTION BUS
-   iob_split
-     #(
+   iob_split #(
 `ifdef RUN_EXTMEM
        .N_SLAVES(2),
 `else
@@ -92,8 +89,7 @@ module system
 `endif
        .P_SLAVES(`E_BIT)
        )
-   ibus_split
-     (
+   ibus_split (
       .clk_i (clk_i),
       .rst_i (cpu_reset),
       // master interface
@@ -121,13 +117,11 @@ module system
    wire [`REQ_W-1:0]         int_d_req;
    wire [`RESP_W-1:0]        int_d_resp;
 
-   iob_split
-     #(
+   iob_split #(
        .N_SLAVES(2), //E,{P,I}
        .P_SLAVES(`E_BIT)
        )
-   dbus_split
-     (
+   dbus_split (
       .clk_i    ( clk_i   ),
       .rst_i    ( cpu_reset ),
 
@@ -152,13 +146,11 @@ module system
    wire [`REQ_W-1:0]         pbus_req;
    wire [`RESP_W-1:0]        pbus_resp;
 
-   iob_split
-     #(
+   iob_split #(
        .N_SLAVES(2), //P,I
        .P_SLAVES(`P_BIT)
        )
-   int_dbus_split
-     (
+   int_dbus_split (
       .clk_i (clk_i),
       .rst_i (cpu_reset),
 
@@ -186,13 +178,11 @@ module system
    wire [`IOB_SOC_N_SLAVES*`REQ_W-1:0] slaves_req;
    wire [`IOB_SOC_N_SLAVES*`RESP_W-1:0] slaves_resp;
 
-   iob_split
-     #(
+   iob_split #(
        .N_SLAVES(`IOB_SOC_N_SLAVES),
        .P_SLAVES(`P_BIT-1)
        )
-   pbus_split
-     (
+   pbus_split (
       .clk_i (clk_i),
       .rst_i (cpu_reset),
       // master interface
@@ -209,16 +199,14 @@ module system
    // INTERNAL SRAM MEMORY
    //
 
-   int_mem 
-    #(
-        .ADDR_W(ADDR_W),
-        .DATA_W(DATA_W),
-        .BOOTROM_ADDR_W(BOOTROM_ADDR_W),
-        .SRAM_ADDR_W(SRAM_ADDR_W),
-        .B_BIT(`B_BIT)
-    )
-    int_mem0
-     (
+   int_mem #(
+      .ADDR_W(ADDR_W),
+      .DATA_W(DATA_W),
+      .BOOTROM_ADDR_W(BOOTROM_ADDR_W),
+      .SRAM_ADDR_W(SRAM_ADDR_W),
+      .B_BIT(`B_BIT)
+      ) 
+   int_mem0 (
       .clk_i(clk_i),
       .rst_i(rst_i),
       .cke_i(cke_i),
@@ -239,23 +227,25 @@ module system
    //
    // EXTERNAL DDR MEMORY
    //
-   ext_mem
-     #(
+   ext_mem #(
        .AXI_ID_W(AXI_ID_W),
        .AXI_LEN_W(AXI_LEN_W),
        .AXI_ADDR_W(AXI_ADDR_W),
        .AXI_DATA_W(AXI_DATA_W)
        )
-   ext_mem0
-   (
+   ext_mem0 (
       // instruction bus
       .i_req ( {ext_mem_i_req[`avalid(0)], ext_mem_i_req[`address(0, SRAM_ADDR_W)-2], ext_mem_i_req[`write(0)]} ),
       .i_resp (ext_mem_i_resp),
 
+      // data bus
+      .d_req ( {ext_mem_d_req[`avalid(0)], ext_mem_d_req[`address(0, DCACHE_ADDR_W+1)-2], ext_mem_d_req[`write(0)]} ),
+      .d_resp (ext_mem_d_resp),
+
       //AXI INTERFACE 
-      `include "iob_axi_m_portmap.vh"
-      .clk (clk_i),
-      .rst (cpu_reset)
+      `include "iob_axi_m_m_portmap.vh"
+      .clk_i  (clk_i),
+      .arst_i (cpu_reset)
       );
 `endif
 

--- a/iob_soc_setup.py
+++ b/iob_soc_setup.py
@@ -13,7 +13,7 @@ meta = \
 meta['build_dir']=f"../{meta['name']+'_'+meta['version']}"
 meta['submodules'] = {
     'hw_setup': {
-        'v_headers' : [ 'iob_wire', 'axi_wire', 'axi_m_m_portmap', 'axi_m_port', 'axi_m_portmap', ],
+        'v_headers' : [ 'iob_wire', 'axi_wire', 'axi_m_m_portmap', 'axi_m_port', 'axi_m_m_portmap', ],
         'hw_modules': [ 'PICORV32', 'CACHE', 'UART', 'iob_merge.v', 'iob_split.v', 'iob_rom_sp.v', 'iob_ram_dp_be.v', 'iob_pulse_gen.v', 'iob_counter.v', 'iob_ram_2p_asym.v', 'iob_reg.v', 'iob_reg_re.v' ]
     },
     'sim_setup': {
@@ -50,7 +50,7 @@ confs = \
 [
     # SoC defines
     {'name':'INIT_MEM',      'type':'D', 'val':'1', 'min':'0', 'max':'1', 'descr':"Enable memory initialization"},
-    {'name':'RUN_EXTMEM',    'type':'D', 'val':'0', 'min':'0', 'max':'1', 'descr':"Run firmware from external memory"}, #This is the new USE_DDR
+    {'name':'RUN_EXTMEM',    'type':'D', 'val':'0', 'min':'0', 'max':'1', 'descr':"Run firmware from external memory"}, # USE_DDR was merged with RUN_EXTMEM
 
     # SoC macros
     {'name':'USE_MUL_DIV',   'type':'M', 'val':'1', 'min':'0', 'max':'1', 'descr':"Enable MUL and DIV CPU instrunctions"},
@@ -58,7 +58,6 @@ confs = \
     {'name':'E',             'type':'M', 'val':'31', 'min':'1', 'max':'32', 'descr':"Address selection bit for external memory"},
     {'name':'P',             'type':'M', 'val':'30', 'min':'1', 'max':'32', 'descr':"Address selection bit for peripherals"},
     {'name':'B',             'type':'M', 'val':'29', 'min':'1', 'max':'32', 'descr':"Address selection bit for boot ROM"},
-    {'name':'DCACHE_ADDR_W', 'type':'M', 'val':'24', 'min':'1', 'max':'32', 'descr':"DCACHE address width"},
     {'name':'DDR_DATA_W',    'type':'M', 'val':'32', 'min':'1', 'max':'32', 'descr':"DDR data bus width"},
     {'name':'DDR_ADDR_W',    'type':'M', 'val':'24', 'min':'1', 'max':'32', 'descr':"DDR address bus width in simulation"},
     #TODO: Need to find a way to use value below when running on fpga
@@ -73,6 +72,7 @@ confs = \
     {'name':'DATA_W',        'type':'P', 'val':'32', 'min':'1', 'max':'32', 'descr':"Data bus width"},
     {'name':'BOOTROM_ADDR_W','type':'P', 'val':'12', 'min':'1', 'max':'32', 'descr':"Boot ROM address width"},
     {'name':'SRAM_ADDR_W',   'type':'P', 'val':'15', 'min':'1', 'max':'32', 'descr':"SRAM address width"},
+    {'name':'DCACHE_ADDR_W', 'type':'P', 'val':'24', 'min':'1', 'max':'32', 'descr':"DCACHE address width"},
     {'name':'AXI_ID_W',      'type':'P', 'val':'0', 'min':'1', 'max':'32', 'descr':"AXI ID bus width"},
     {'name':'AXI_ADDR_W',    'type':'P', 'val':'`IOB_SOC_DCACHE_ADDR_W', 'min':'1', 'max':'32', 'descr':"AXI address bus width"},
     {'name':'AXI_DATA_W',    'type':'P', 'val':'`IOB_SOC_DATA_W', 'min':'1', 'max':'32', 'descr':"AXI data bus width"},
@@ -88,6 +88,7 @@ ios = \
         {'name':"rst_i", 'type':"I", 'n_bits':'1', 'descr':"System reset, synchronous and active high"},
         {'name':"trap_o", 'type':"O", 'n_bits':'1', 'descr':"CPU trap signal"}
     ]},
+    {'name': 'axi_m_port', 'descr':'General interface signals', 'ports': [], 'if_defined':'RUN_EXTMEM'},
 ]
 
 


### PR DESCRIPTION
With RUN_EXTMEM=1 simulation blocks because the rvalid and ready signal are not correctly working with the iob-cache.
Now ios can have the `'is_defined':'SOMETHING'` key which creates and `ifdef SOMETHING ... endif` in the Verilog header automatically generated.