### PR TITLE
Fix `IOB_SOC_RUN_EXTMEM` macro name

### DIFF
--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_fpga_wrapper.v
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_fpga_wrapper.v
@@ -11,7 +11,7 @@ module iob_soc_fpga_wrapper
    output        uart_txd,
    input         uart_rxd,
 
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
    output [13:0] ddr3b_a, //SSTL15  //Address
    output [2:0]  ddr3b_ba, //SSTL15  //Bank Address
    output        ddr3b_rasn, //SSTL15  //Row Address Strobe
@@ -44,7 +44,7 @@ module iob_soc_fpga_wrapper
 
    wire 	 rst;
 
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
    //axi wires between system backend and axi bridge
  `include "iob_soc_axi_m_wire.vh"
 `endif
@@ -63,7 +63,7 @@ module iob_soc_fpga_wrapper
       .general_rst_i (rst),
       .general_trap_o (trap),
 
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
       `include "iob_soc_axi_m_portmap.vh"	
 `endif
 
@@ -75,7 +75,7 @@ module iob_soc_fpga_wrapper
       );
 
    
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
    //user reset
    wire          locked;
    wire          init_done;

--- a/hardware/fpga/vivado/AES-KU040-DB-G/iob_soc_fpga_wrapper.v
+++ b/hardware/fpga/vivado/AES-KU040-DB-G/iob_soc_fpga_wrapper.v
@@ -13,7 +13,7 @@ module iob_soc_fpga_wrapper
    output        uart_txd,
    input         uart_rxd,
 
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
    output        c0_ddr4_act_n,
    output [16:0] c0_ddr4_adr,
    output [1:0]  c0_ddr4_ba,
@@ -41,7 +41,7 @@ module iob_soc_fpga_wrapper
    wire          clk;
    wire 	 rst;
    
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
    //axi wires between system backend and axi bridge
  `include "iob_soc_axi_m_wire.vh"
 `endif
@@ -63,7 +63,7 @@ module iob_soc_fpga_wrapper
       .general_rst_i (rst),
       .general_trap_o (trap),
 
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
       //axi system backend interface
  `include "iob_soc_axi_m_portmap.vh"	
 `endif
@@ -80,7 +80,7 @@ module iob_soc_fpga_wrapper
    // DDR4 CONTROLLER
    //
                  
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
 
    //axi wires between ddr4 contrl and axi interconnect
  `include "ddr4_axi_wire.vh"

--- a/hardware/simulation/src/iob_soc_top.vt
+++ b/hardware/simulation/src/iob_soc_top.vt
@@ -43,7 +43,7 @@ module system_top (
 
    //AXI wires for connecting system to memory
 
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
    `include "iob_axi_wire.vh"
 `endif
 
@@ -58,7 +58,7 @@ module system_top (
       )
     uut (
       //PORTS
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
       `include "iob_axi_m_portmap.vh"
 `endif               
       .general_clk_i (clk_i),
@@ -68,7 +68,7 @@ module system_top (
 
 
    //instantiate the axi memory
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
     axi_ram #(
       .FILE("iob_soc_firmware.hex"),
       .FILE_SIZE(2**(`IOB_SOC_SRAM_ADDR_W-2)),

--- a/hardware/src/iob_soc.vt
+++ b/hardware/src/iob_soc.vt
@@ -47,7 +47,12 @@ module iob_soc #(
        .E_BIT(`E_BIT),
        .P_BIT(`P_BIT),
        .USE_COMPRESSED(`IOB_SOC_USE_COMPRESSED),
-       .USE_MUL_DIV(`IOB_SOC_USE_MUL_DIV)
+       .USE_MUL_DIV(`IOB_SOC_USE_MUL_DIV),
+`ifdef IOB_SOC_RUN_EXTMEM
+       .RUN_EXTMEM(1)
+`else
+       .RUN_EXTMEM(0)
+`endif
        )
    cpu (
         .clk_i (clk_i),
@@ -74,7 +79,7 @@ module iob_soc #(
    wire [`REQ_W-1:0]  int_mem_i_req;
    wire [`RESP_W-1:0] int_mem_i_resp;
    //external memory instruction bus
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
    wire [`REQ_W-1:0]  ext_mem_i_req;
    wire [`RESP_W-1:0] ext_mem_i_resp;
 
@@ -105,7 +110,7 @@ module iob_soc #(
    //internal data bus
    wire [`REQ_W-1:0]         int_d_req;
    wire [`RESP_W-1:0]        int_d_resp;
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
    //external memory data bus
    wire [`REQ_W-1:0]         ext_mem_d_req;
    wire [`RESP_W-1:0]        ext_mem_d_resp;
@@ -214,7 +219,7 @@ module iob_soc #(
       .d_resp (int_mem_d_resp)
       );
 
-`ifdef RUN_EXTMEM
+`ifdef IOB_SOC_RUN_EXTMEM
    //
    // EXTERNAL DDR MEMORY
    //

--- a/iob_soc_setup.py
+++ b/iob_soc_setup.py
@@ -78,7 +78,7 @@ ios = \
         {'name':"rst_i", 'type':"I", 'n_bits':'1', 'descr':"System reset, synchronous and active high"},
         {'name':"trap_o", 'type':"O", 'n_bits':'1', 'descr':"CPU trap signal"}
     ]},
-    {'name': 'axi_m_port', 'descr':'General interface signals', 'ports': [], 'if_defined':'RUN_EXTMEM'},
+    {'name': 'axi_m_port', 'descr':'General interface signals', 'ports': [], 'if_defined':'IOB_SOC_RUN_EXTMEM'},
 ]
 
 # Main function to setup this system and its components

--- a/software/bootloader/iob_soc_boot.c
+++ b/software/bootloader/iob_soc_boot.c
@@ -34,11 +34,11 @@ int main() {
 
   // address to copy firmware to
   char *prog_start_addr;
-//#ifdef RUN_EXTMEM
-//    prog_start_addr = (char *) EXTRA_BASE; //FIXME: Temporarly disabled as there is an issue loading firmware
-//#else
+#ifdef RUN_EXTMEM
+    prog_start_addr = (char *) EXTRA_BASE;
+#else
     prog_start_addr = (char *) (1<<BOOTROM_ADDR_W);
-//#endif
+#endif
 
   while(uart_getc() != ACK){
     uart_puts (PROGNAME);


### PR DESCRIPTION
- Use correct `IOB_SOC_RUN_EXTMEM` macro in Verilog sources
- Remove temporary fix from iob_soc_boot.c as it is no longer required.
- Update PICORV32. It now includes a RUN_EXTMEM parameter.