### PR TITLE
Add default.nix; Update README; Resolve issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Older versions of the dependencies above may work but were not tested.
 
 ## Nix environment
 
-Instead of manually installing the dependencies above, you can use 
-[nix-shell](https://nixos.org/download.html#nix-install-linux) to run 
-IOb-SoC in a [Nix](https://nixos.org/) environment with all dependencies 
+Instead of manually installing the dependencies above, you can use
+[nix-shell](https://nixos.org/download.html#nix-install-linux) to run
+IOb-SoC in a [Nix](https://nixos.org/) environment with all dependencies
 available except for Vivado and Quartus.
 
 - Run `nix-shell` from the IOb-SoC root directory to install and start the environment with all the required dependencies.
@@ -39,7 +39,7 @@ available except for Vivado and Quartus.
 IOb-SoC can be run on a VirtualBox VM. This way, the system can be quickly tried
 without investing much time installing the tools:
 
-1. Donwload and install [Oracle's VirtualBox](https://www.virtualbox.org/wiki/Downloads)
+1. Download and install [Oracle's VirtualBox](https://www.virtualbox.org/wiki/Downloads)
 2. Download [IOb-SoC VM](https://drive.google.com/file/d/1X4OXI4JiBLwK7BJPAEG1voxVaFYS9V-f/view?usp=share_link)
 
 
@@ -53,7 +53,8 @@ for CentOS 7 and Ubuntu 18.04 or 20.04 LTS.
 The first step is to clone this repository. IOb-SoC uses git sub-module trees, and
 GitHub will ask for your password for each downloaded module if you clone by *https*. To avoid this,
 setup GitHub access with *ssh* and type:
-```
+
+```Bash
 git clone --recursive git@github.com:IObundle/iob-soc.git
 cd iob-soc
 ```
@@ -83,9 +84,9 @@ these settings in your `.bashrc` file, so that they apply to every session.
 Using open-source simulator Icarus Verilog as an example, note that in
 `hardware/simulation/icarus/Makefile`, the variable for the server logical name,
 `SIM_SERVER`, is set to `IVSIM_SERVER`, and the variable for the user name,
-`SIM_USER`, is set to `IVSIM_USER`. If you do not set these variables the 
-simulator will run locally. To run the simulator on server 
-*mysimserver.myorg.com* as user *ivsimuser*, set the following environmental 
+`SIM_USER`, is set to `IVSIM_USER`. If you do not set these variables the
+simulator will run locally. To run the simulator on server
+*mysimserver.myorg.com* as user *ivsimuser*, set the following environmental
 variables beforehand:
 
 ```Bash
@@ -97,10 +98,10 @@ export IVSIM_USER=ivsimuser
 
 Using the CYCLONEV-GT-DK board as an example, note that in
 `hardware/fpga/quartus/CYCLONEV-GT-DK/Makefile` the variable for the FPGA tool
-server logical name, `FPGA_SERVER`, is set to `QUARTUS_SERVER`, and the 
-variable for the user name, `FPGA_USER`, is set to `QUARTUS_USER`; the 
-variable for the board server, `BOARD_SERVER`, is set to `CYC5_SERVER`, and 
-the variable for the board user, `BOARD_USER`, is set to `CYC5_USER`. As in the 
+server logical name, `FPGA_SERVER`, is set to `QUARTUS_SERVER`, and the
+variable for the user name, `FPGA_USER`, is set to `QUARTUS_USER`; the
+variable for the board server, `BOARD_SERVER`, is set to `CYC5_SERVER`, and
+the variable for the board user, `BOARD_USER`, is set to `CYC5_USER`. As in the
 previous example, set these variables as follows:
 
 ```Bash
@@ -122,7 +123,7 @@ export LM_LICENSE_FILE=port@licenseserver.myorg.com;lic_or_dat_file
 
 ### Set up Nix environment on remote servers
 
-If you want to run IOb-SoC on the remote servers inside a [Nix](https://nixos.org/) environment, you should 
+If you want to run IOb-SoC on the remote servers inside a [Nix](https://nixos.org/) environment, you should
 edit the server's `.bashrc` file to launch the environment before running the commands.
 The IOb-SoC system uses the command `ssh <remote> <command>` to run commands on the remote server.
 
@@ -130,11 +131,11 @@ Add the following code to the top of the server's `.bashrc` file to launch the N
 when ssh commands are executed:
 
 ```Bash
-# Check if connected via ssh and is a non interactive session
+# Check if connected via ssh and is a non-interactive session
 if [ -n "$SSH_CONNECTION" ] && [[ $- != *i* ]]; then
-    # Get command sent via ssh, that should run in the Nix environment
+    # Get the command sent via ssh, which should run in the Nix environment
     NIX_CMD=`ps -o args= $$ | cut -d ' ' -f3-`
-    # Replace current shell by a nix-shell environment and run the command
+    # Replace the current shell with a nix-shell environment and run the command
     exec $NIX_PATH/nix-shell $NIX_DEPS/shell.nix --run "$NIX_CMD"
 fi
 ```
@@ -143,21 +144,21 @@ NOTE: The `$NIX_PATH` variable should be replaced by the path to the nix-shell b
 Run `whereis nix-shell` on the remote machine to obtain the correct path.
 
 NOTE: The `$NIX_DEPS` variable should be replaced by the path to the [shell.nix](https://github.com/IObundle/iob-lib/blob/python-setup/nix/shell.nix) file.
-This file is located in the `nix/` directory of the [IOb-Lib](https://github.com/IObundle/iob-lib) repository. 
-Copy this file to a fixed location on the remote machine and replace the `$NIX_DEPS` variable by it's path.
+This file is located in the `nix/` directory of the [IOb-Lib](https://github.com/IObundle/iob-lib) repository.
+Copy this file to a fixed location on the remote machine and replace the `$NIX_DEPS` variable with its path.
 
 
 It is possible to add an extra `if` statement to only run certain tools in the Nix environment.
-This may be useful since some tools, like quartus, don't run well in the Nix environment.
+This may be useful since some tools, like Quartus, don't run well in the Nix environment.
 
 ```Bash
-# Check if connected via ssh and is a non interactive session
+# Check if connected via ssh and is a non-interactive session
 if [ -n "$SSH_CONNECTION" ] && [[ $- != *i* ]]; then
-    # Get command sent via ssh, that should run in the Nix environment
+    # Get the command sent via ssh, which should run in the Nix environment
     NIX_CMD=`ps -o args= $$ | cut -d ' ' -f3-`
     # Only run environment if a specified tool is used in the command
     if [[ "$NIX_CMD" == *"verilator"* ]]; then
-        # Replace current shell by a nix-shell environment and run the command
+        # Replace the current shell with a nix-shell environment and run the command
         exec $NIX_PATH/nix-shell -p verilator --run "$NIX_CMD"
     fi
 fi
@@ -169,75 +170,101 @@ fi
 
 The main configuration for the system is located in the `iob_soc_setup.py` file.
 
-To setup the system, type:
+To set up the system, type:
 
-```
+```Bash
 make setup [<control parameters>]
 ```
 
 `<control parameters>` are system configuration parameters passed in the
 command line, overriding those in the `iob_soc_setup.py` file. Example control
 parameters are `INIT_MEM=0 USE_EXTMEM=1`. For example,
-```
+
+```Bash
 make setup INIT_MEM=0 USE_EXTMEM=1
 ```
 
 The setup process will create a build directory that contains all the files required for building the system.
 
+The **setup directory** is considered to be the repository folder, as it contains the files needed to set up the system.
+
+The **build directory** is considered to be the folder generated by the setup process, as it contains the files needed to build the system.
+The build directory is usually located in `../iob\_soc\_V*` relative to the setup directory.
+
+To further configure the setup process, you can create/modify the following scripts:
+- hardware/fpga/fpga\_setup.py
+- hardware/fpga/sim\_setup.py
+- software/sw\_setup.py
+Even though all of the scripts above will be called during the setup process, it is useful
+to separate them in different scripts according to their use purpose, mostly for organization
+purposes.
+If this system is included by another primary one, the primary system will have control over
+which sections of this system should be set up.
+
+Most Makefiles and Makefile
+
+
 ## Simulate the system
 
 To simulate IOb-SoC, the simulator must be installed, either locally or
 remotely. If you are using the Nix environment the simulator is automatically installed.
-To simulate, from the build directory, type:
+To simulate, navigate to the build directory and type:
 
-```
+```Bash
 make [sim-run] [SIMULATOR=<simulator directory name>]
 ```
 
 `<simulator directory name>` is the name of the simulator's run directory,
-TODO: UPDATE BELOW
 To visualise simulation waveforms use the `VCD=1` control parameter. It will
 open the Gtkwave waveform visualisation program.
 
-To clean simulation generated files, type:
+You can also run the simulation directly from the setup directory (the root
+directory of this repository) by typing:
+
+```Bash
+make -C ../iob_soc_V* [sim-run] [SIMULATOR=<simulator directory name>]
 ```
-make sim-clean [SIMULATOR=<simulator directory name>] 
+
+To clean simulation-generated files, type:
+
+```Bash
+make -C ../iob_soc_V* sim-clean [SIMULATOR=<simulator directory name>]
 # Example
-make sim-clean SIMULATOR=icarus
+make -C ../iob_soc_V* sim-clean SIMULATOR=icarus
 ```
 
-For more details, read the Makefile in each simulator directory. The Makefile
-includes the Makefile segment `simulation.mk`, which contains statements that
-apply to any simulator. In turn, `simulation.mk` includes the Makefile segment
-`hardware.mk`, which contains targets common to all hardware tools. The 
-`hardware.mk` includes `config.mk`,  which contains main system parameters. The
-Makefile in the simulator's directory, with the segments recursively included as
-described, is construed as a single large Makefile.
+For more details, read the Makefile segments in the `hardware/simulaton/` directory
+of the build directory. The Makefile of the simulation directory includes the
+Makefile segment of the simulator being used, that contains simulator specific configuration.
 
-## Emulate the system on PC 
+The simulation Makefile also includes the sim\_build.mk that can be user created in the simulation
+folder of the setup directory. The sim\_build.mk file allows overriding Makefile variables for
+simulation, and adding extra Makefile targets that can be used to generate files required by
+the project.
+
+The simulation Makefile also includes system info from the config\_build.mk file that
+is auto-generated during setup.
+
+
+## Emulate the system on PC
 
 If there are embedded software compilation or runtime issues you can
 *emulate* the system on a PC to debug the issues. To emulate IOb-SoC's embedded
 software on a PC, type:
 
-```
-make pc-emul [<control parameters>]
-```
-where `<control parameters>` are system configuration parameters passed in the
-command line, overriding those in the `config.mk` file. Example control
-parameters are `INIT_MEM=0 USE_EXTMEM=1`. For example,
-```
-make pc-emul INIT_MEM=0 USE_EXTMEM=1
+```Bash
+make -C ../iob_soc_V* pc-emul
 ```
 
 To clean the PC compilation generated files, type:
-```
-make pc-emul-clean
+
+```Bash
+make -C ../iob_soc_V* pc-emul-clean
 ```
 
-For more details, read the Makefile in the `software/pc-emul` directory. As
-explained for the simulation make file, note the Makefile segments recursively
-included.
+For more details, read the Makefile in the `software/pc-emul/` directory. As
+explained for the simulation make file, note the Makefile includes the pcemul\_build.mk
+Makefile segment for project-specific configuration.
 
 
 ## Build and run on FPGA board
@@ -247,62 +274,62 @@ installed, either locally or remotely, the board must be attached to the local
 host or to a remote host, and each board must have a build directory under the
 `hardware/fpga/<tool>` directory, for example the `hardware/fpga/vivado/BASYS3`
 directory. The FPGA tools and board hosts may be different.
+The host machine must have the [board\_server.py](https://github.com/IObundle/iob-lib/blob/python-setup/scripts/board_server.py)
+running. This file can be copied from the [IOb-Lib](https://github.com/IObundle/iob-lib) repository
+and set up to run as a service.
 
 To build only, type
-``` 
-make fpga-build [BOARD=<board directory name>] [<control parameters>]
-``` 
-where `<board directory name>` is the name of the board's run directory, and
-`<control parameters>` are system configuration parameters passed in the command
-line, overriding those in the `config.mk` file. For example, 
-``` 
-make fpga-build BOARD=BASYS3 INIT_MEM=0 USE_EXTMEM=1
-``` 
 
-For more details read the Makefile in the board directory, and follow the
-recursively included Makefile segments as explained before.
+```Bash
+make -C ../iob_soc_V* fpga-build [BOARD=<board directory name>]
+```
+where `<board directory name>` is the name of the board's run directory, and
+
+For more details read the Makefile in the `hardware/fpga/` folder of the build directory,
+and follow the included Makefile segments as explained before.
 
 To build and run, type:
-``` 
-make fpga-run [BOARD=<board directory name>] [<control parameters>]
-``` 
 
-The FPGA is loaded with the configuration bitstream before running. However,
-this step is skipped if the bitstream checksum matches that of the last loaded
-bitstream, kept in file `/tmp/<board directory name>.load`. If, for some reason,
-the run gets stuck, you may interrupt it with `Ctr-C`. Then, you may try again
-forcing the bitstream to be reloaded using control parameter `FORCE=1`.
+```Bash
+make -C ../iob_soc_V* fpga-run [BOARD=<board directory name>]
+```
 
-If many users are trying to run the same FPGA board they will be queued in file
-`/tmp/<board directory name>.queue`. Users will orderly load their bitstream
-onto the board and start running it. After a successful run or `Ctr-C` 
-interrupt, the user is de-queued.
+To manage multiple clients' connections to the same board, the system uses the
+[board\_server.py](https://github.com/IObundle/iob-lib/blob/python-setup/scripts/board_server.py)
+python server.
+If many users are trying to run the same FPGA board they will be queued by the server.
+Users will orderly load their bitstream onto the board and start running it.
+After a successful run or `Ctr-C` interrupt, the user is de-queued.
 
+If, for some reason, the run gets stuck, you may interrupt it with `Ctr-C`.
 
 To clean the FPGA compilation generated files, type
-``` 
-make fpga-clean [BOARD=<board directory name>]
-``` 
+
+```Bash
+make -C ../iob_soc_V* fpga-clean [BOARD=<board directory name>]
+```
 
 ## Compile the documentation
 
 To compile documents, the LaTeX document preparation software must be
-installed. Each document that can be compiled has a build directory under the
-`document` directory. Currently there are two document build directories:
-`presentation` and `pb` (product brief). The document to build is specified by
-the DOC control parameter. To compile the document, type:
-```
-make doc [DOC=<document directory name>]
+installed. The system can auto-generate a user guide based on TeX templates
+and system configuration.
+
+To compile the document, type:
+
+```Bash
+make -C ../iob_soc_V* doc [DOC=<document directory name>]
 ```
 
 
 To clean the document's build directory, type:
-```
-make doc-clean [DOC=<document directory name>]
+
+```Bash
+make -C ../iob_soc_V* doc-clean [DOC=<document directory name>]
 ```
 
-For more details, read the Makefile in each document's directory, and follow the
-recursively included Makefile segments as explained before.
+For more details, read the Makefile in the `document/` folder of the build directory,
+and follow the included Makefile segments as explained before.
 
 
 ## Testing
@@ -312,8 +339,8 @@ recursively included Makefile segments as explained before.
 To run a series of simulation tests on the simulator selected by the SIMULATOR
 variable, type:
 
-```
-make sim-test [SIMULATOR=<simulator directory>]
+```Bash
+make -C ../iob_soc_V* sim-test [SIMULATOR=<simulator directory>]
 ```
 
 The above command produces a test log file called `test.log` in the simulator's
@@ -321,16 +348,16 @@ directory. The `test.log` file is compared with the `test.expected` file, which
 resides in the same directory; if they differ, the test fails; otherwise, it
 passes.
 
-To run the series of simulation tests on all supported simulators, type:
-
-```
-make test-sim 
-```
-
 To clean the files produced when testing all simulators, type:
 
+```Bash
+make -C ../iob_soc_V* test-sim-clean
 ```
-make test-sim-clean
+
+To test the setup, build and simulation process for all configurations, type:
+
+```Bash
+make sim-test [SIMULATOR=<simulator directory>]
 ```
 
 
@@ -339,8 +366,8 @@ make test-sim-clean
 To compile and run a series of board tests on the board selected by the `BOARD`
 variable, type:
 
-```
-make fpga-test [BOARD=<board directory name>]
+```Bash
+make -C ../iob_soc_V* fpga-test [BOARD=<board directory name>]
 ```
 
 The above command produces a test log file called `test.log` in the board's
@@ -348,46 +375,42 @@ directory. The `test.log` file is compared with the `test.expected` file, which
 resides in the same directory; if they differ, the test fails; otherwise, it
 passes.
 
-To run the series of board tests on all supported boards, type:
-
-```
-make test-fpga 
-```
-
 To clean the files produced when testing all boards, type:
-```
-make test-fpga-clean
+
+```Bash
+make -C ../iob_soc_V* test-fpga-clean
 ```
 
+To test the setup, build and FPGA run process for all configurations, type:
+
+```Bash
+make fpga-test [BOARD=<board directory name>]
+```
 
 
 ### Documentation test
 
 To compile and test the document selected by the `DOC`, variable, type:
 
-```
-make doc-test [DOC=<document directory name>]
+```Bash
+make -C ../iob_soc_V* doc-test [DOC=<document directory name>]
 ```
 
 The resulting Latex .aux file is compared with a known-good .aux file. If the
 match the test passes; otherwise it fails.
 
-To test all supported documents, type:
-
-```
-make test-doc
-```
-
 To clean the files produced when testing all documents, type:
-```
-make test-doc-clean
+
+```Bash
+make -C ../iob_soc_V* test-doc-clean
 ```
 
 ### Total test
 
 To run all simulation, FPGA board and documentation tests, type:
-```
-make test
+
+```Bash
+make test-all
 ```
 
 ## Cleaning
@@ -395,17 +418,22 @@ make test
 The following command will clean the selected simulation, board and document
 directories, locally and in the remote servers:
 
-```
-make clean
+```Bash
+make -C ../iob_soc_V* clean
 ```
 
+The following command will delete the build directory:
+
+```Bash
+make clean
+```
 
 
 ## Instructions for Installing the RISC-V GNU Compiler Toolchain
 
 ### Get sources and checkout the supported stable version
 
-```
+```Bash
 git clone https://github.com/riscv/riscv-gnu-toolchain
 cd riscv-gnu-toolchain
 git checkout 2022.06.10
@@ -415,24 +443,26 @@ git checkout 2022.06.10
 
 For the Ubuntu OS and its variants:
 
-```
+```Bash
 sudo apt install autoconf automake autotools-dev curl python3 python2 libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo gperf libtool patchutils bc zlib1g-dev libexpat-dev
 ```
 
 For CentOS and its variants:
-```
+
+```Bash
 sudo yum install autoconf automake python3 python2 libmpc-devel mpfr-devel gmp-devel gawk  bison flex texinfo patchutils gcc gcc-c++ zlib-devel expat-devel
 ```
 
 ### Installation
 
-```
+```Bash
 ./configure --prefix=/path/to/riscv --enable-multilib
 sudo make -j$(nproc)
 ```
 
 This will take a while. After it is done, type:
-```
+
+```Bash
 export PATH=$PATH:/path/to/riscv/bin
 ```
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,1 @@
+submodules/LIB/nix/shell.nix

--- a/hardware/simulation/src/iob_soc_tb.vt
+++ b/hardware/simulation/src/iob_soc_tb.vt
@@ -6,7 +6,7 @@
 `include "iob_uart_swreg_def.vh"
 
 
-//PHEADER
+//IOB_PRAGMA_PHEADERS
 
 module iob_soc_tb;
 

--- a/hardware/simulation/src/iob_soc_top.vt
+++ b/hardware/simulation/src/iob_soc_top.vt
@@ -4,7 +4,7 @@
 `include "iob_soc_conf.vh"
 `include "iob_lib.vh"
 
-//PHEADER
+//IOB_PRAGMA_PHEADERS
 
 module iob_soc_top (
    output                             trap_o,
@@ -25,7 +25,7 @@ module iob_soc_top (
    localparam AXI_ADDR_W=`DDR_ADDR_W;
    localparam AXI_DATA_W=`IOB_SOC_DATA_W;
  
-   //PWIRES
+   //IOB_PRAGMA_PWIRES
 
    
    /////////////////////////////////////////////
@@ -58,7 +58,7 @@ module iob_soc_top (
       .AXI_DATA_W(AXI_DATA_W)
       )
     uut (
-      //PORTS
+      //IOB_PRAGMA_PPORTMAPS
 `ifdef IOB_SOC_USE_EXTMEM
       `include "iob_axi_m_portmap.vh"
 `endif               

--- a/hardware/src/iob_soc.vt
+++ b/hardware/src/iob_soc.vt
@@ -228,7 +228,7 @@ module iob_soc #(
        .ADDR_W(ADDR_W),
        .DATA_W(DATA_W),
        .FIRM_ADDR_W(SRAM_ADDR_W),
-       .DCACHE_ADDR_W(DCACHE_ADDR_W),
+       .MEM_ADDR_W(`MEM_ADDR_W),
        .DDR_ADDR_W(`DDR_ADDR_W),
        .DDR_DATA_W(`DDR_DATA_W),
        .AXI_ID_W(AXI_ID_W),
@@ -242,7 +242,7 @@ module iob_soc #(
       .i_resp (ext_mem_i_resp),
 
       // data bus
-      .d_req ( {ext_mem_d_req[`avalid(0)], ext_mem_d_req[`address(0, DCACHE_ADDR_W+1)-2], ext_mem_d_req[`write(0)]} ),
+      .d_req ( {ext_mem_d_req[`avalid(0)], ext_mem_d_req[`address(0, `MEM_ADDR_W+1)-2], ext_mem_d_req[`write(0)]} ),
       .d_resp (ext_mem_d_resp),
 
       //AXI INTERFACE 

--- a/hardware/src/iob_soc.vt
+++ b/hardware/src/iob_soc.vt
@@ -6,7 +6,7 @@
 `include "iob_lib.vh"
 
 //do not remove line below
-//PHEADER
+//IOB_PRAGMA_PHEADERS
 
 module iob_soc #(
     `include "iob_soc_params.vh"
@@ -253,6 +253,6 @@ module iob_soc #(
       );
 `endif
 
-   //peripheral instances are inserted here
+  //IOB_PRAGMA_PERIPHS
 
 endmodule

--- a/iob_soc_setup.py
+++ b/iob_soc_setup.py
@@ -62,9 +62,8 @@ confs = \
     #mandatory parameters (do not change them!)
     {'name':'ADDR_W',        'type':'P', 'val':'32', 'min':'1', 'max':'32', 'descr':"Address bus width"},
     {'name':'DATA_W',        'type':'P', 'val':'32', 'min':'1', 'max':'32', 'descr':"Data bus width"},
-    {'name':'DCACHE_ADDR_W', 'type':'P', 'val':'24', 'min':'1', 'max':'32', 'descr':"DCACHE address width"},
     {'name':'AXI_ID_W',      'type':'P', 'val':'0', 'min':'1', 'max':'32', 'descr':"AXI ID bus width"},
-    {'name':'AXI_ADDR_W',    'type':'P', 'val':'`IOB_SOC_DCACHE_ADDR_W', 'min':'1', 'max':'32', 'descr':"AXI address bus width"},
+    {'name':'AXI_ADDR_W',    'type':'P', 'val':'`MEM_ADDR_W', 'min':'1', 'max':'32', 'descr':"AXI address bus width"},
     {'name':'AXI_DATA_W',    'type':'P', 'val':'`IOB_SOC_DATA_W', 'min':'1', 'max':'32', 'descr':"AXI data bus width"},
     {'name':'AXI_LEN_W',     'type':'P', 'val':'4', 'min':'1', 'max':'4', 'descr':"AXI burst length width"},
 ]


### PR DESCRIPTION
- Remove DCACHE_ADDR_W from iob_soc_setup.py as the new macro is set by the new LIB. This resolves https://github.com/IObundle/iob-soc/issues/529.
- Along with the new LIB, this resolves issue IObundle/iob-lib#430.
- Update README with instructions for usage of Nix environment.
- Add default.nix symlink to new shell.nix of new LIB.
- Update README according to new python-setup process.