### PR TITLE
Update LIB; Remove `build_configuration.*` includes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,5 @@ test-all:
 	make fpga-test BOARD=CYCLONEV-GT-DK
 	make fpga-test BOARD=AES-KU040-DB-G
 	make clean && make setup && make -C ../iob_soc_V*/ doc-test
+
+.PHONY: sim-test fpga-test test-all

--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_fpga_wrapper.v
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_fpga_wrapper.v
@@ -1,6 +1,5 @@
 `timescale 1ns / 1ps
 `include "iob_soc_conf.vh"
-`include "build_configuration.vh"
 
 module iob_soc_fpga_wrapper
   (

--- a/hardware/fpga/vivado/AES-KU040-DB-G/iob_soc_fpga_wrapper.v
+++ b/hardware/fpga/vivado/AES-KU040-DB-G/iob_soc_fpga_wrapper.v
@@ -1,6 +1,5 @@
 `timescale 1ns / 1ps
 `include "iob_soc_conf.vh"
-`include "build_configuration.vh"
 
 module iob_soc_fpga_wrapper
   (

--- a/hardware/simulation/src/iob_soc_tb.cpp
+++ b/hardware/simulation/src/iob_soc_tb.cpp
@@ -5,7 +5,6 @@
 #include "verilated.h"
 #include "verilated_vcd_c.h"
 
-#include "build_configuration.h"
 #include "iob_soc_conf.h"
 #include "iob_uart_swreg.h"
 

--- a/hardware/simulation/src/iob_soc_tb.vt
+++ b/hardware/simulation/src/iob_soc_tb.vt
@@ -1,6 +1,5 @@
 `timescale 1ns / 1ps
 
-`include "build_configuration.vh"
 `include "iob_soc_conf.vh"
 `include "iob_uart_conf.vh"
 `include "iob_uart_swreg_def.vh"

--- a/hardware/simulation/src/iob_soc_top.vt
+++ b/hardware/simulation/src/iob_soc_top.vt
@@ -1,6 +1,5 @@
 `timescale 1ns / 1ps
 
-`include "build_configuration.vh"
 `include "iob_soc_conf.vh"
 `include "iob_lib.vh"
 

--- a/hardware/src/iob_soc.vt
+++ b/hardware/src/iob_soc.vt
@@ -1,6 +1,5 @@
 `timescale 1 ns / 1 ps
 
-`include "build_configuration.vh"
 `include "iob_soc_conf.vh"
 `include "iob_soc.vh"
 `include "iob_lib.vh"

--- a/hardware/src/sram.v
+++ b/hardware/src/sram.v
@@ -1,6 +1,5 @@
 `timescale 1ns / 1ps
 
-`include "build_configuration.vh"
 `include "iob_soc_conf.vh"
 
 module sram #(

--- a/software/bootloader/iob_soc_boot.c
+++ b/software/bootloader/iob_soc_boot.c
@@ -1,4 +1,3 @@
-#include "build_configuration.h"
 #include "iob_soc_system.h"
 #include "iob_soc_conf.h"
 #include "iob-uart.h"

--- a/software/firmware/iob_soc_firmware.c
+++ b/software/firmware/iob_soc_firmware.c
@@ -1,4 +1,3 @@
-#include "build_configuration.h"
 #include "iob_soc_system.h"
 #include "iob_soc_periphs.h"
 #include "iob_soc_conf.h"


### PR DESCRIPTION
- Remove `build_configuration.vh` and `build_configuration.h` file includes, as these files are no longer generated by the new LIB. The new LIB uses a `$(DEFINES)` list stored in the `build_defines.txt` file at the root of the build directory. The tools use this list to   set the defines at run-time.
- Update LIB
- Add .PHONY targets