### PR TITLE
Update LIB and `CONSOLE_CMD`; Fix small bugs.

### DIFF
--- a/hardware/simulation/sim_build.mk
+++ b/hardware/simulation/sim_build.mk
@@ -16,7 +16,7 @@ VTOP:=iob_soc_sim_wrapper
 
 endif
 
-CONSOLE_CMD=../../scripts/console.py -L
+CONSOLE_CMD=rm -f soc2cnsl cnsl2soc; ../../scripts/console.py -L
 
 TEST_LIST+=test1
 test1:

--- a/hardware/simulation/src/iob_soc_sim_wrapper.vt
+++ b/hardware/simulation/src/iob_soc_sim_wrapper.vt
@@ -3,6 +3,7 @@
 `include "bsp.vh"
 `include "iob_soc_conf.vh"
 `include "iob_lib.vh"
+`include "iob_uart_swreg_def.vh"
 
 //IOB_PRAGMA_PHEADERS
 

--- a/software/sw_build.mk
+++ b/software/sw_build.mk
@@ -67,8 +67,8 @@ EMUL_SRC+=src/iob_str.c
 # PERIPHERAL SOURCES
 EMUL_SRC+=$(wildcard src/iob-*.c)
 
-EMUL_TEST_LIST+=test1
-test1:
+EMUL_TEST_LIST+=pc-emul-test1
+pc-emul-test1:
 	make run_emul TEST_LOG="> test.log"
 
 


### PR DESCRIPTION
- Add missing include.
- Rename pc-emul test to prevent overrides.
- Update LIB with new modifications to ssh connections and `board_client.py` version `V0.2`.
- Update `CONSOLE_CMD` variable from `sim_build.mk`.

The new LIB in this PR includes changes from PR: https://github.com/IObundle/iob-lib/pull/486