### PR TITLE
Remove unneeded file; Update LIB.

### DIFF
--- a/hardware/simulation/sim_build.mk
+++ b/hardware/simulation/sim_build.mk
@@ -18,6 +18,8 @@ endif
 
 CONSOLE_CMD=rm -f soc2cnsl cnsl2soc; ../../scripts/console.py -L
 
+GRAB_TIMEOUT ?= 3600
+
 TEST_LIST+=test1
 test1:
 	make -C ../../ fw-clean SIMULATOR=$(SIMULATOR) && make -C ../../ sim-clean SIMULATOR=$(SIMULATOR) && make run SIMULATOR=$(SIMULATOR)

--- a/hardware/simulation/src/iob_soc_sim_wrapper.vt
+++ b/hardware/simulation/src/iob_soc_sim_wrapper.vt
@@ -3,7 +3,6 @@
 `include "bsp.vh"
 `include "iob_soc_conf.vh"
 `include "iob_lib.vh"
-`include "iob_uart_swreg_def.vh"
 
 //IOB_PRAGMA_PHEADERS
 


### PR DESCRIPTION
- Remove unneeded `include iob_uart_swreg_def.vh` since it is auto-inserted by the python scripts during the setup process. This is a partial revert of commit eda4fa1.
- Update LIB