### PR TITLE
Compilation fixed again and more preparations

### DIFF
--- a/iob_soc.py
+++ b/iob_soc.py
@@ -235,30 +235,6 @@ class iob_soc(iob_module):
                 },
                 # parameters
                 {
-                    "name": "BOOTROM_ADDR_W",
-                    "type": "P",
-                    "val": "12",
-                    "min": "1",
-                    "max": "32",
-                    "descr": "Boot ROM address width",
-                },
-                {
-                    "name": "PREBOOT_BOOTROM_ADDR_W",
-                    "type": "P",
-                    "val": "8",
-                    "min": "1",
-                    "max": "32",
-                    "descr": "Preboot ROM address width",
-                },
-                {
-                    "name": "BOOT_BOOTROM_ADDR_W",
-                    "type": "P",
-                    "val": "11",
-                    "min": "1",
-                    "max": "32",
-                    "descr": "Preboot ROM address width",
-                },
-                {
                     "name": "SRAM_ADDR_W",
                     "type": "P",
                     "val": "15",

--- a/scripts/iob_soc_create_periphs_tmp.py
+++ b/scripts/iob_soc_create_periphs_tmp.py
@@ -10,16 +10,17 @@ from submodule_utils import *
 # Arguments:
 #   periph_addr_select_bit: Adress selection bit (P variable)
 #   peripherals_list: list with amount of instances of each peripheral (returned by get_peripherals())
-def create_periphs_tmp(addr_w, peripherals_list, out_file):
+def create_periphs_tmp(addr_w, peripherals_list, out_file, top):
     # Don't override output file
     if os.path.isfile(out_file):
         return
 
+    prefix = f"{top}_".upper()
     template_contents = []
     for instance in peripherals_list:
         template_contents.extend(
-            "#define {}_BASE ({}<<({}-1-N_SLAVES_W))\n".format(
-                instance.name, instance.name, addr_w
+            "#define {}_BASE ({}<<({}-1-{}N_SLAVES_W))\n".format(
+                instance.name, prefix + instance.name, addr_w, prefix
             )
         )
 

--- a/scripts/iob_soc_utils.py
+++ b/scripts/iob_soc_utils.py
@@ -39,6 +39,7 @@ def iob_soc_sw_setup(python_module, exclude_files=[]):
             next(i["val"] for i in confs if i["name"] == "ADDR_W"),
             peripherals_list,
             f"{build_dir}/software/{name}_periphs.h",
+            name,
         )
 
 

--- a/software/src/iob_soc_firmware.S
+++ b/software/src/iob_soc_firmware.S
@@ -1,14 +1,18 @@
 #include "iob_soc_conf.h"
 #include "iob_soc_periphs.h"
 
-#define CTR_ADDR (BOOT0_BASE+(1<<BOOTROM_ADDR_W))
+// Can't include iob_soc_boot_conf.h because the assembler doesn't recognize stdint.h,
+// so define the constants here instead (these are address offsets).
+#define IOB_SOC_BOOT_CTR 0
+
+#define CTR_ADDR (BOOT0_BASE+IOB_SOC_BOOT_CTR)
 
 .section .init
 .global main
 
 //set stack pointer
-lui sp, %hi(1<<SRAM_ADDR_W)
-addi sp, sp, %lo(1<<SRAM_ADDR_W)
+lui sp, %hi(1<<IOB_SOC_SRAM_ADDR_W)
+addi sp, sp, %lo(1<<IOB_SOC_SRAM_ADDR_W)
 
 //call main
 jal ra, main

--- a/software/src/iob_soc_firmware.c
+++ b/software/src/iob_soc_firmware.c
@@ -57,7 +57,8 @@ int main() {
   printf("Value of Pi = %f\n\n", 3.1415);
 
   ///////////////////////////////
-  /*IOB_SOC_BOOT_INIT_BASEADDR(BOOT0_BASE);
+  // Test get "Preboot string!" from preboot rom
+  IOB_SOC_BOOT_INIT_BASEADDR(BOOT0_BASE);
 
   char str[100] = {0};
   for (int i = 0; i < 30; i += 4) {
@@ -72,9 +73,10 @@ int main() {
       break;
     }
   }
-  printf("String: %s\n", str);*/
+  printf("String: %s\n", str);
 
   // return 0;
+  ///////////////////////////////
 
   // test file send
   char *sendfile = malloc(1000);

--- a/software/src/iob_soc_system.h
+++ b/software/src/iob_soc_system.h
@@ -1,6 +1,6 @@
 // extra memory base address
 // extra memory is SRAM if running from DDR or DDR if running from SRAM
-#define EXTRA_BASE (1 << E)
+#define EXTRA_BASE (1 << IOB_SOC_E)
 
 // boot controller base address
-#define BOOTCTR_BASE (1 << B)
+#define BOOTCTR_BASE (1 << IOB_SOC_B)

--- a/software/src/python-setup/iob_soc_system.h
+++ b/software/src/python-setup/iob_soc_system.h
@@ -1,6 +1,6 @@
 // extra memory base address
 // extra memory is SRAM if running from DDR or DDR if running from SRAM
-#define EXTRA_BASE (1 << E)
+#define EXTRA_BASE (1 << IOB_SOC_E)
 
 // boot controller base address
-#define BOOTCTR_BASE (1 << B)
+#define BOOTCTR_BASE (1 << IOB_SOC_B)

--- a/software/sw_build.mk
+++ b/software/sw_build.mk
@@ -9,19 +9,19 @@ ROOT_DIR ?=..
 GET_MACRO = $(shell grep "define $(1)" $(2) | rev | cut -d" " -f1 | rev)
 
 #Function to obtain parameter named $(1) from iob_soc_conf.vh
-GET_IOB_SOC_CONF_MACRO = $(call GET_MACRO,IOB_SOC_$(1),../src/iob_soc_conf.vh)
+GET_IOB_SOC_CONF_MACRO = $(call GET_MACRO,$(1),../src/iob_soc_conf.vh)
 
 iob_soc_preboot.hex: ../../software/iob_soc_preboot.bin
-	../../scripts/makehex.py $< $(call GET_IOB_SOC_CONF_MACRO,PREBOOT_BOOTROM_ADDR_W) > $@
+	../../scripts/makehex.py $< $(call GET_IOB_SOC_CONF_MACRO,IOB_SOC_BOOT0_PREBOOT_ROM_ADDR_W) > $@
 
 iob_soc_boot.hex: ../../software/iob_soc_boot.bin
-	../../scripts/makehex.py $< $(call GET_IOB_SOC_CONF_MACRO,BOOT_BOOTROM_ADDR_W) > $@
+	../../scripts/makehex.py $< $(call GET_IOB_SOC_CONF_MACRO,IOB_SOC_BOOT0_BOOT_ROM_ADDR_W) > $@
 
 iob_soc_rom.hex: iob_soc_preboot.hex iob_soc_boot.hex
 	cat $^ > $@
 
 iob_soc_firmware.hex: iob_soc_firmware.bin
-	../../scripts/makehex.py $< $(call GET_IOB_SOC_CONF_MACRO,SRAM_ADDR_W) > $@
+	../../scripts/makehex.py $< $(call GET_IOB_SOC_CONF_MACRO,IOB_SOC_SRAM_ADDR_W) > $@
 	../../scripts/hex_split.py iob_soc_firmware .
 
 iob_soc_firmware.bin: ../../software/iob_soc_firmware.bin

--- a/submodules/BOOT/iob_soc_boot.py
+++ b/submodules/BOOT/iob_soc_boot.py
@@ -10,10 +10,6 @@ from iob_reg_e import iob_reg_e
 from iob_pulse_gen import iob_pulse_gen
 from iob_rom_dp import iob_rom_dp
 
-# these 2 values should be passed from the top level but are hardcoded for now
-# BASE = 0x40000000
-ROM_ADDR_W = 10
-
 
 class iob_soc_boot(iob_module):
     name = "iob_soc_boot"
@@ -58,9 +54,25 @@ class iob_soc_boot(iob_module):
                     "descr": "Address bus width",
                 },
                 {
-                    "name": "BOOTROM_ADDR_W",
+                    "name": "FULL_ROM_ADDR_W",
                     "type": "F",
-                    "val": str(ROM_ADDR_W),
+                    "val": "12",
+                    "min": "NA",
+                    "max": "24",
+                    "descr": "Boot ROM address width",
+                },
+                {
+                    "name": "BOOT_ROM_ADDR_W",
+                    "type": "F",
+                    "val": "11",
+                    "min": "NA",
+                    "max": "24",
+                    "descr": "Boot ROM address width",
+                },
+                {
+                    "name": "PREBOOT_ROM_ADDR_W",
+                    "type": "F",
+                    "val": "8",
                     "min": "NA",
                     "max": "24",
                     "descr": "Boot ROM address width",
@@ -123,7 +135,7 @@ class iob_soc_boot(iob_module):
                         "n_bits": "DATA_W",
                         "rst_val": 0,
                         "addr": -1,
-                        "log2n_items": 10,  # todo Make this be automatic ("passed from the top level")
+                        "log2n_items": "FULL_ROM_ADDR_W - 2",
                         "autologic": False,
                         "descr": "Bootloader ROM.",
                     },

--- a/submodules/BOOT/iob_soc_boot.py
+++ b/submodules/BOOT/iob_soc_boot.py
@@ -59,7 +59,7 @@ class iob_soc_boot(iob_module):
                     "val": "12",
                     "min": "NA",
                     "max": "24",
-                    "descr": "Boot ROM address width",
+                    "descr": "Full ROM (preboot+bootloader) address width",
                 },
                 {
                     "name": "BOOT_ROM_ADDR_W",
@@ -67,7 +67,7 @@ class iob_soc_boot(iob_module):
                     "val": "11",
                     "min": "NA",
                     "max": "24",
-                    "descr": "Boot ROM address width",
+                    "descr": "Bootloader ROM address width",
                 },
                 {
                     "name": "PREBOOT_ROM_ADDR_W",
@@ -75,7 +75,7 @@ class iob_soc_boot(iob_module):
                     "val": "8",
                     "min": "NA",
                     "max": "24",
-                    "descr": "Boot ROM address width",
+                    "descr": "Preboot ROM address width",
                 },
             ]
         )

--- a/submodules/BOOT/software/src/iob_soc_boot.S
+++ b/submodules/BOOT/software/src/iob_soc_boot.S
@@ -5,8 +5,8 @@
 .global main
 
 //set stack pointer
-lui sp, %hi(1<<SRAM_ADDR_W)
-addi sp, sp, %lo(1<<SRAM_ADDR_W)
+lui sp, %hi(1<<IOB_SOC_SRAM_ADDR_W)
+addi sp, sp, %lo(1<<IOB_SOC_SRAM_ADDR_W)
 
 //call main
 jal ra, main

--- a/submodules/BOOT/software/src/iob_soc_boot.c
+++ b/submodules/BOOT/software/src/iob_soc_boot.c
@@ -1,5 +1,6 @@
 #include "bsp.h"
 #include "iob-uart.h"
+#include "iob_soc_boot_conf.h"
 #include "iob_soc_conf.h"
 #include "iob_soc_periphs.h"
 #include "iob_soc_system.h"
@@ -35,7 +36,7 @@ int main() {
 #ifdef USE_EXTMEM
   prog_start_addr = (char *)EXTRA_BASE;
 #else
-  prog_start_addr = (char *)(1 << BOOTROM_ADDR_W);
+  prog_start_addr = (char *)(1 << IOB_SOC_BOOT_FULL_ROM_ADDR_W);
 #endif
 
   while (uart_getc() != ACK) {

--- a/submodules/BOOT/software/src/iob_soc_preboot.S
+++ b/submodules/BOOT/software/src/iob_soc_preboot.S
@@ -1,17 +1,22 @@
-#include "iob_soc_boot_swreg.h"
+#include "iob_soc_boot_conf.h"
 #include "iob_soc_conf.h"
 #include "iob_soc_periphs.h"
 
-#define BOOTROM (BOOT0_BASE + IOB_SOC_BOOT_ROM + 1 << PREBOOT_BOOTROM_ADDR_W)
-#define BOOTRAM ((1<<31) + (1<<MEM_ADDR_W) - (1<<BOOT_BOOTROM_ADDR_W))
+// Can't include iob_soc_boot_conf.h because the assembler doesn't recognize stdint.h,
+// so define the constants here instead (these are address offsets).
+#define IOB_SOC_BOOT_ROM 0
+#define IOB_SOC_BOOT_CTR 0
+
+#define BOOTROM (BOOT0_BASE + IOB_SOC_BOOT_ROM + 1 << IOB_SOC_BOOT_PREBOOT_ROM_ADDR_W)
+#define BOOTRAM ((1<<31) + (1<<IOB_SOC_MEM_ADDR_W) - (1<<IOB_SOC_BOOT_BOOT_ROM_ADDR_W))
 //#define BOOTRAM 7168 //((1 << 31) + (1 << MEM_ADDR_W) - (1 << BOOT_BOOTROM_ADDR_W))
-#define LENGTH (1 << BOOTROM_ADDR_W) - (1 << PREBOOT_BOOTROM_ADDR_W)
+#define LENGTH (1 << IOB_SOC_BOOT_FULL_ROM_ADDR_W) - (1 << IOB_SOC_BOOT_PREBOOT_ROM_ADDR_W)
 #define CTR_ADDR (BOOT0_BASE + IOB_SOC_BOOT_CTR)
 
 .section .init
 .globl _start
 
-//.string "Preboot string!\n"
+.string "Preboot string!\n"
 
 _start:
   li x1, LENGTH


### PR DESCRIPTION
List of changes:
- The project is compiling again (still with the python-setup files).
- More preparations were made to get the BOOT as a peripheral.
- The project is right now getting a string from the preboot rom (or the full rom, which begins with the preboot one) on the firmware stage.
- All peripheral and iob-soc *_conf.h files are now using the same format as put on LIB: begin with the peripheral name.
- Some BOOT macros removed from the top module and put instead on the peripheral files.

NOTE: compilation fixed for INIT_MEM=1 and USE_EXTMEM=1. I didn't test the other cases. This is one of the most important ones anyway. USE_EXTMEM=0 is not important (int_mem will be removed).