### PR TITLE
Fix `axi_m_port` interface; Fix iob_soc_create_system.py; Update submodules.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ setup:
 	nix-shell --run 'make build-setup SETUP_ARGS="$(SETUP_ARGS)"'
 
 pc-emul-run:
-	nix-shell --run 'make clean && make setup && make -C ../$(CORE)_V*/ pc-emul-run'
+	nix-shell --run 'make clean setup && make -C ../$(CORE)_V*/ pc-emul-run'
 
 pc-emul-test:
-	nix-shell --run 'make clean && make setup && make -C ../$(CORE)_V*/ pc-emul-test'
+	nix-shell --run 'make clean setup && make -C ../$(CORE)_V*/ pc-emul-test'
 
 sim-run:
 	nix-shell --run 'make clean setup INIT_MEM=$(INIT_MEM) USE_EXTMEM=$(USE_EXTMEM) && make -C ../$(CORE)_V*/ sim-run SIMULATOR=$(SIMULATOR)'
@@ -36,7 +36,7 @@ sim-test:
 	nix-shell --run 'make clean setup INIT_MEM=0 USE_EXTMEM=1 && make -C ../$(CORE)_V*/ sim-test SIMULATOR=verilator'
 
 fpga-run:
-	nix-shell --run 'make clean && make setup INIT_MEM=$(INIT_MEM) USE_EXTMEM=$(USE_EXTMEM) && make -C ../$(CORE)_V*/ fpga-fw-build BOARD=$(BOARD)'
+	nix-shell --run 'make clean setup INIT_MEM=$(INIT_MEM) USE_EXTMEM=$(USE_EXTMEM) && make -C ../$(CORE)_V*/ fpga-fw-build BOARD=$(BOARD)'
 	make -C ../$(CORE)_V*/ fpga-run BOARD=$(BOARD)
 
 fpga-test:
@@ -46,9 +46,14 @@ fpga-test:
 	make clean setup fpga-run BOARD=AES-KU040-DB-G INIT_MEM=0 USE_EXTMEM=1 
 
 
+doc-build:
+	nix-shell --run 'make clean setup && make -C ../$(CORE)_V*/ doc-build'
+
 doc-test:
-	nix-shell --run 'make clean && make setup && make -C ../$(CORE)_V*/ doc-test'
+	nix-shell --run 'make clean setup && make -C ../$(CORE)_V*/ doc-test'
+
 
 test-all: pc-emul-test sim-test fpga-test doc-test
+
 
 .PHONY: setup sim-test fpga-test doc-test test-all

--- a/hardware/src/iob_soc.v
+++ b/hardware/src/iob_soc.v
@@ -159,7 +159,7 @@ module iob_soc #(
    // INTERNAL SRAM MEMORY
    //
 
-   int_mem #(
+   iob_soc_int_mem #(
       .ADDR_W        (ADDR_W),
       .DATA_W        (DATA_W),
       .HEXFILE       ("iob_soc_firmware"),
@@ -205,7 +205,7 @@ module iob_soc #(
    wire [AXI_ADDR_W-1:0] internal_axi_awaddr_o;
    wire [AXI_ADDR_W-1:0] internal_axi_araddr_o;
 
-   ext_mem #(
+   iob_soc_ext_mem #(
       .ADDR_W     (ADDR_W),
       .DATA_W     (DATA_W),
       .FIRM_ADDR_W(SRAM_ADDR_W),
@@ -236,19 +236,19 @@ module iob_soc #(
       .axi_awcache_o(axi_awcache_o[0+:4]),
       .axi_awprot_o (axi_awprot_o[0+:3]),
       .axi_awqos_o  (axi_awqos_o[0+:4]),
-      .axi_awvalid_o(axi_awvalid_o),
-      .axi_awready_i(axi_awready_i),
+      .axi_awvalid_o(axi_awvalid_o[0+:1]),
+      .axi_awready_i(axi_awready_i[0+:1]),
       //write
       .axi_wdata_o  (axi_wdata_o[0+:AXI_DATA_W]),
       .axi_wstrb_o  (axi_wstrb_o[0+:(AXI_DATA_W/8)]),
-      .axi_wlast_o  (axi_wlast_o),
-      .axi_wvalid_o (axi_wvalid_o),
-      .axi_wready_i (axi_wready_i),
+      .axi_wlast_o  (axi_wlast_o[0+:1]),
+      .axi_wvalid_o (axi_wvalid_o[0+:1]),
+      .axi_wready_i (axi_wready_i[0+:1]),
       //write response
       .axi_bid_i    (axi_bid_i[0+:AXI_ID_W]),
       .axi_bresp_i  (axi_bresp_i[0+:2]),
-      .axi_bvalid_i (axi_bvalid_i),
-      .axi_bready_o (axi_bready_o),
+      .axi_bvalid_i (axi_bvalid_i[0+:1]),
+      .axi_bready_o (axi_bready_o[0+:1]),
       //address read
       .axi_arid_o   (axi_arid_o[0+:AXI_ID_W]),
       .axi_araddr_o (internal_axi_araddr_o[0+:AXI_ADDR_W]),
@@ -259,15 +259,15 @@ module iob_soc #(
       .axi_arcache_o(axi_arcache_o[0+:4]),
       .axi_arprot_o (axi_arprot_o[0+:3]),
       .axi_arqos_o  (axi_arqos_o[0+:4]),
-      .axi_arvalid_o(axi_arvalid_o),
-      .axi_arready_i(axi_arready_i),
+      .axi_arvalid_o(axi_arvalid_o[0+:1]),
+      .axi_arready_i(axi_arready_i[0+:1]),
       //read
       .axi_rid_i    (axi_rid_i[0+:AXI_ID_W]),
       .axi_rdata_i  (axi_rdata_i[0+:AXI_DATA_W]),
       .axi_rresp_i  (axi_rresp_i[0+:2]),
-      .axi_rlast_i  (axi_rlast_i),
-      .axi_rvalid_i (axi_rvalid_i),
-      .axi_rready_o (axi_rready_o),
+      .axi_rlast_i  (axi_rlast_i[0+:1]),
+      .axi_rvalid_i (axi_rvalid_i[0+:1]),
+      .axi_rready_o (axi_rready_o[0+:1]),
 
       .clk_i (clk_i),
       .cke_i (cke_i),

--- a/hardware/src/iob_soc_boot_ctr.v
+++ b/hardware/src/iob_soc_boot_ctr.v
@@ -1,6 +1,6 @@
 `timescale 1 ns / 1 ps
 
-module boot_ctr #(
+module iob_soc_boot_ctr #(
    parameter HEXFILE        = "boot.hex",
    parameter DATA_W         = 0,
    parameter ADDR_W         = 0,

--- a/hardware/src/iob_soc_ext_mem.v
+++ b/hardware/src/iob_soc_ext_mem.v
@@ -2,7 +2,7 @@
 
 `include "iob_utils.vh"
 
-module ext_mem #(
+module iob_soc_ext_mem #(
    parameter ADDR_W      = 0,
    parameter DATA_W      = 0,
    parameter FIRM_ADDR_W = 0,

--- a/hardware/src/iob_soc_int_mem.v
+++ b/hardware/src/iob_soc_int_mem.v
@@ -3,7 +3,7 @@
 `include "iob_soc_conf.vh"
 `include "iob_utils.vh"
 
-module int_mem #(
+module iob_soc_int_mem #(
    parameter ADDR_W         = 0,
    parameter DATA_W         = 0,
    parameter HEXFILE        = "firmware",
@@ -70,7 +70,7 @@ module int_mem #(
    wire [ `REQ_W-1:0] ram_w_req;
    wire [`RESP_W-1:0] ram_w_resp;
 
-   boot_ctr #(
+   iob_soc_boot_ctr #(
       .HEXFILE       ({BOOT_HEXFILE, ".hex"}),
       .DATA_W        (DATA_W),
       .ADDR_W        (ADDR_W),
@@ -158,7 +158,7 @@ module int_mem #(
    //
    // INSTANTIATE RAM
    //
-   sram #(
+   iob_soc_sram #(
 `ifndef IOB_SOC_USE_EXTMEM
 `ifdef IOB_SOC_INIT_MEM
       .HEXFILE    (HEXFILE),

--- a/hardware/src/iob_soc_sram.v
+++ b/hardware/src/iob_soc_sram.v
@@ -2,7 +2,7 @@
 `include "iob_soc_conf.vh"
 `include "bsp.vh"
 
-module sram #(
+module iob_soc_sram #(
    parameter DATA_W      = `IOB_SOC_DATA_W,
    parameter SRAM_ADDR_W = `IOB_SOC_SRAM_ADDR_W,
    parameter HEXFILE     = "none"

--- a/iob_soc.py
+++ b/iob_soc.py
@@ -7,6 +7,7 @@ from iob_module import iob_module
 from iob_block_group import iob_block_group
 from iob_soc_utils import pre_setup_iob_soc, post_setup_iob_soc
 from mk_configuration import update_define
+from verilog_tools import inplace_change
 
 # Submodules
 from iob_picorv32 import iob_picorv32
@@ -56,6 +57,13 @@ class iob_soc(iob_module):
         """Setup this system using specialized iob-soc functions"""
         # Pre-setup specialized IOb-SoC functions
         num_extmem_connections = pre_setup_iob_soc(cls)
+        # Remove `[0+:1]` part select in AXI connections of ext_mem0 in iob_soc.v template
+        if num_extmem_connections == 1:
+            inplace_change(
+                os.path.join(cls.build_dir, "hardware/src", cls.name + ".v"),
+                "[0+:1])",
+                ")",
+            )
         # Generate hw, sw, doc files
         super()._generate_files()
         # Post-setup specialized IOb-SoC functions

--- a/scripts/iob_soc_create_system.py
+++ b/scripts/iob_soc_create_system.py
@@ -149,7 +149,7 @@ def create_systemv(build_dir, top, peripherals_list, internal_wires=None):
 # axi_awid_width: String representing the width of the axi_awid signal.
 def get_extmem_bus_size(axi_awid_width: str):
     # Parse the size of the ext_mem bus, it should be something like "N*AXI_ID_W", where N is the size of the bus
-    bus_size = re.findall("^(?:(\d+)\*)?AXI_ID_W$", axi_awid_width)
+    bus_size = re.findall("^(?:\((\d+)\*)?AXI_ID_W\)?$", axi_awid_width)
     # Make sure parse of with was successful
     assert (
         bus_size != []

--- a/scripts/iob_soc_utils.py
+++ b/scripts/iob_soc_utils.py
@@ -241,7 +241,7 @@ def post_setup_iob_soc(python_module, num_extmem_connections):
             )
         # Copy joinHexFiles.py from LIB
         build_srcs.copy_files(
-            "submodules/LIB", f"{build_dir}/scripts", ["joinHexFiles.py"], "*.py"
+            build_srcs.LIB_DIR, f"{build_dir}/scripts", ["joinHexFiles.py"], "*.py"
         )
 
 

--- a/submodules/LIB/scripts/iob_module.py
+++ b/submodules/LIB/scripts/iob_module.py
@@ -363,7 +363,7 @@ class iob_module:
                         "rst_val": build_srcs.version_str_to_digits(cls.version),
                         "addr": -1,
                         "log2n_items": 0,
-                        "autologic": True,
+                        "autoreg": True,
                         "descr": "Product version.  This 16-bit register uses nibbles to represent decimal numbers using their binary values. The two most significant nibbles represent the integral part of the version, and the two least significant nibbles represent the decimal part. For example V12.34 is represented by 0x1234.",
                     }
                 )

--- a/submodules/LIB/scripts/mkregs.py
+++ b/submodules/LIB/scripts/mkregs.py
@@ -179,7 +179,7 @@ class mkregs:
         )
 
         if not auto:  # output read enable
-            if "W" not in row['type']:
+            if "W" not in row["type"]:
                 f.write(f"wire {name}_addressed;\n")
                 f.write(
                     f"assign {name}_addressed = (iob_addr_i >= {addr}) && (iob_addr_i < ({addr}+(2**({addr_w}))));\n"
@@ -199,16 +199,24 @@ class mkregs:
             if name != "VERSION":
                 if "W" in row["type"]:
                     if auto:
-                        f.write(f"  output [{self.verilog_max(n_bits,1)}-1:0] {name}_o,\n")
+                        f.write(
+                            f"  output [{self.verilog_max(n_bits,1)}-1:0] {name}_o,\n"
+                        )
                     else:
-                        f.write(f"  output [{self.verilog_max(n_bits,1)}-1:0] {name}_wdata_o,\n")
+                        f.write(
+                            f"  output [{self.verilog_max(n_bits,1)}-1:0] {name}_wdata_o,\n"
+                        )
                         f.write(f"  output {name}_wen_o,\n")
                         f.write(f"  input {name}_wready_i,\n")
                 if "R" in row["type"]:
                     if auto:
-                        f.write(f"  input [{self.verilog_max(n_bits,1)}-1:0] {name}_i,\n")
+                        f.write(
+                            f"  input [{self.verilog_max(n_bits,1)}-1:0] {name}_i,\n"
+                        )
                     else:
-                        f.write(f"  input [{self.verilog_max(n_bits,1)}-1:0] {name}_rdata_i,\n")
+                        f.write(
+                            f"  input [{self.verilog_max(n_bits,1)}-1:0] {name}_rdata_i,\n"
+                        )
                         f.write(f"  output {name}_ren_o,\n")
                         f.write(f"  input {name}_rvalid_i,\n")
                         f.write(f"  input {name}_rready_i,\n")
@@ -244,14 +252,18 @@ class mkregs:
                     if auto:
                         f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_wr;\n")
                     else:
-                        f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_wdata_wr;\n")
+                        f.write(
+                            f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_wdata_wr;\n"
+                        )
                         f.write(f"wire {name}_wen_wr;\n")
                         f.write(f"wire {name}_wready_wr;\n")
                 if "R" in row["type"]:
                     if auto:
                         f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_rd;\n")
                     else:
-                        f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_rdata_rd;\n")
+                        f.write(
+                            f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_rdata_rd;\n"
+                        )
                         f.write(f"wire {name}_ren_rd;\n")
                         f.write(f"wire {name}_rvalid_rd;\n")
                         f.write(f"wire {name}_rready_rd;\n")

--- a/submodules/LIB/scripts/mkregs.py
+++ b/submodules/LIB/scripts/mkregs.py
@@ -93,18 +93,17 @@ class mkregs:
             n_bytes = 4
         addr = row["addr"]
         addr_w = self.calc_verilog_addr_w(log2n_items, n_bytes)
-        auto = row["autologic"]
+        auto = row["autoreg"]
 
         f.write(
             f"\n\n//NAME: {name};\n//TYPE: {row['type']}; WIDTH: {n_bits}; RST_VAL: {rst_val}; ADDR: {addr}; SPACE (bytes): {2**self.calc_addr_w(log2n_items,n_bytes)} (max); AUTO: {auto}\n\n"
         )
 
         # compute wdata with only the needed bits
-        if auto:
-            f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_wdata; \n")
-            f.write(
-                f"assign {name}_wdata = iob_wdata_i[{self.boffset(addr,self.cpu_n_bytes)}+:{self.verilog_max(n_bits,1)}];\n"
-            )
+        f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_wdata; \n")
+        f.write(
+            f"assign {name}_wdata = iob_wdata_i[{self.boffset(addr,self.cpu_n_bytes)}+:{self.verilog_max(n_bits,1)}];\n"
+        )
 
         # signal to indicate if the register is addressed
         f.write(f"wire {name}_addressed;\n")
@@ -161,6 +160,7 @@ class mkregs:
             f.write(
                 f"assign {name}_wen_o = ({name}_addressed & iob_avalid_i)? |iob_wstrb_i: 1'b0;\n"
             )
+            f.write(f"assign {name}_wdata_o = {name}_wdata;\n")
 
     def gen_rd_reg(self, row, f):
         name = row["name"]
@@ -172,17 +172,18 @@ class mkregs:
             n_bytes = 4
         addr = row["addr"]
         addr_w = self.calc_verilog_addr_w(log2n_items, n_bytes)
-        auto = row["autologic"]
+        auto = row["autoreg"]
 
         f.write(
             f"\n\n//NAME: {name};\n//TYPE: {row['type']}; WIDTH: {n_bits}; RST_VAL: {rst_val}; ADDR: {addr}; SPACE (bytes): {2**self.calc_addr_w(log2n_items,n_bytes)} (max); AUTO: {auto}\n\n"
         )
 
         if not auto:  # output read enable
-            f.write(f"wire {name}_addressed;\n")
-            f.write(
-                f"assign {name}_addressed = (iob_addr_i >= {addr}) && (iob_addr_i < ({addr}+(2**({addr_w}))));\n"
-            )
+            if "W" not in row['type']:
+                f.write(f"wire {name}_addressed;\n")
+                f.write(
+                    f"assign {name}_addressed = (iob_addr_i >= {addr}) && (iob_addr_i < ({addr}+(2**({addr_w}))));\n"
+                )
             f.write(
                 f"assign {name}_ren_o = {name}_addressed & iob_avalid_i & (~|iob_wstrb_i);\n"
             )
@@ -192,24 +193,25 @@ class mkregs:
         for row in table:
             name = row["name"]
             n_bits = row["n_bits"]
-            auto = row["autologic"]
+            auto = row["autoreg"]
 
             # VERSION is not a register, it is an internal constant
             if name != "VERSION":
-                if row["type"] == "W":
+                if "W" in row["type"]:
                     if auto:
-                        f.write(
-                            f"  output [{self.verilog_max(n_bits,1)}-1:0] {name}_o,\n"
-                        )
+                        f.write(f"  output [{self.verilog_max(n_bits,1)}-1:0] {name}_o,\n")
                     else:
+                        f.write(f"  output [{self.verilog_max(n_bits,1)}-1:0] {name}_wdata_o,\n")
                         f.write(f"  output {name}_wen_o,\n")
-                elif row["type"] == "R":
-                    f.write(f"  input [{self.verilog_max(n_bits,1)}-1:0] {name}_i,\n")
-                    if not auto:
+                        f.write(f"  input {name}_wready_i,\n")
+                if "R" in row["type"]:
+                    if auto:
+                        f.write(f"  input [{self.verilog_max(n_bits,1)}-1:0] {name}_i,\n")
+                    else:
+                        f.write(f"  input [{self.verilog_max(n_bits,1)}-1:0] {name}_rdata_i,\n")
                         f.write(f"  output {name}_ren_o,\n")
                         f.write(f"  input {name}_rvalid_i,\n")
-                if not auto:
-                    f.write(f"  input {name}_ready_i,\n")
+                        f.write(f"  input {name}_rready_i,\n")
 
         f.write(f"  output iob_ready_nxt_o,\n")
         f.write(f"  output iob_rvalid_nxt_o,\n")
@@ -217,7 +219,7 @@ class mkregs:
     # auxiliar read register case name
     def aux_read_reg_case_name(self, row):
         aux_read_reg_case_name = ""
-        if row["type"] == "R":
+        if "R" in row["type"]:
             addr = row["addr"]
             n_bits = row["n_bits"]
             log2n_items = row["log2n_items"]
@@ -234,44 +236,50 @@ class mkregs:
         for row in table:
             name = row["name"]
             n_bits = row["n_bits"]
-            auto = row["autologic"]
+            auto = row["autoreg"]
 
             # VERSION is not a register, it is an internal constant
             if name != "VERSION":
-                if row["type"] == "W":
+                if "W" in row["type"]:
                     if auto:
-                        f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name};\n")
+                        f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_wr;\n")
                     else:
-                        f.write(f"wire {name}_wen;\n")
-                elif row["type"] == "R":
-                    f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name};\n")
-                    if not row["autologic"]:
-                        f.write(f"wire {name}_rvalid;\n")
-                        f.write(f"wire {name}_ren;\n")
-                if not auto:
-                    f.write(f"wire {name}_ready;\n")
+                        f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_wdata_wr;\n")
+                        f.write(f"wire {name}_wen_wr;\n")
+                        f.write(f"wire {name}_wready_wr;\n")
+                if "R" in row["type"]:
+                    if auto:
+                        f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_rd;\n")
+                    else:
+                        f.write(f"wire [{self.verilog_max(n_bits,1)}-1:0] {name}_rdata_rd;\n")
+                        f.write(f"wire {name}_ren_rd;\n")
+                        f.write(f"wire {name}_rvalid_rd;\n")
+                        f.write(f"wire {name}_rready_rd;\n")
         f.write("\n")
 
     # generate portmap for swreg instance in top module
     def gen_portmap(self, table, f):
         for row in table:
             name = row["name"]
-            auto = row["autologic"]
+            auto = row["autoreg"]
 
             # VERSION is not a register, it is an internal constant
             if name != "VERSION":
-                if row["type"] == "W":
+                if "W" in row["type"]:
                     if auto:
-                        f.write(f"  .{name}_o({name}),\n")
+                        f.write(f"  .{name}_o({name}_wr),\n")
                     else:
-                        f.write(f"  .{name}_wen_o({name}_wen),\n")
-                else:
-                    f.write(f"  .{name}_i({name}),\n")
-                    if not auto:
-                        f.write(f"  .{name}_ren_o({name}_ren),\n")
-                        f.write(f"  .{name}_rvalid_i({name}_rvalid),\n")
-                if not auto:
-                    f.write(f"  .{name}_ready_i({name}_ready),\n")
+                        f.write(f"  .{name}_wdata_o({name}_wdata_wr),\n")
+                        f.write(f"  .{name}_wen_o({name}_wen_wr),\n")
+                        f.write(f"  .{name}_wready_i({name}_wready_wr),\n")
+                if "R" in row["type"]:
+                    if auto:
+                        f.write(f"  .{name}_i({name}_rd),\n")
+                    else:
+                        f.write(f"  .{name}_rdata_i({name}_rdata_rd),\n")
+                        f.write(f"  .{name}_ren_o({name}_ren_rd),\n")
+                        f.write(f"  .{name}_rvalid_i({name}_rvalid_rd),\n")
+                        f.write(f"  .{name}_rready_i({name}_rready_rd),\n")
 
         f.write(f"  .iob_ready_nxt_o(iob_ready_nxt),\n")
         f.write(f"  .iob_rvalid_nxt_o(iob_rvalid_nxt),\n")
@@ -348,12 +356,12 @@ class mkregs:
 
         # insert write register logic
         for row in table:
-            if row["type"] == "W":
+            if "W" in row["type"]:
                 self.gen_wr_reg(row, f_gen)
 
         # insert read register logic
         for row in table:
-            if row["type"] == "R":
+            if "R" in row["type"]:
                 self.gen_rd_reg(row, f_gen)
 
         #
@@ -369,7 +377,7 @@ class mkregs:
 
         # auxiliar read register cases
         for row in table:
-            if row["type"] == "R":
+            if "R" in row["type"]:
                 aux_read_reg = self.aux_read_reg_case_name(row)
                 if aux_read_reg:
                     f_gen.write(f"reg {aux_read_reg};\n")
@@ -463,9 +471,9 @@ class mkregs:
             )
             addr_w = self.calc_addr_w(log2n_items, n_bytes)
             addr_w_base = max(log(self.cpu_n_bytes, 2), addr_w)
-            auto = row["autologic"]
+            auto = row["autoreg"]
 
-            if row["type"] == "R":
+            if "R" in row["type"]:
                 aux_read_reg = self.aux_read_reg_case_name(row)
 
                 if self.bfloor(addr, addr_w_base) == self.bfloor(
@@ -486,12 +494,16 @@ class mkregs:
                     f_gen.write(
                         f"    rdata_int[{self.boffset(addr, self.cpu_n_bytes)}+:{8*n_bytes}] = 16'h{rst_val}|{8*n_bytes}'d0;\n"
                     )
-                else:
+                elif auto:
                     f_gen.write(
                         f"    rdata_int[{self.boffset(addr, self.cpu_n_bytes)}+:{8*n_bytes}] = {name}_i|{8*n_bytes}'d0;\n"
                     )
+                else:
+                    f_gen.write(
+                        f"    rdata_int[{self.boffset(addr, self.cpu_n_bytes)}+:{8*n_bytes}] = {name}_rdata_i|{8*n_bytes}'d0;\n"
+                    )
                 if not auto:
-                    f_gen.write(f"    rready_int = {name}_ready_i;\n")
+                    f_gen.write(f"    rready_int = {name}_rready_i;\n")
                     f_gen.write(f"    rvalid_int = {name}_rvalid_i;\n")
                 f_gen.write(f"  end\n\n")
 
@@ -505,15 +517,15 @@ class mkregs:
             if n_bytes == 3:
                 n_bytes = 4
             addr_w = self.calc_addr_w(log2n_items, n_bytes)
-            auto = row["autologic"]
+            auto = row["autoreg"]
 
-            if row["type"] == "W":
+            if "W" in row["type"]:
                 if not auto:
                     # get wready
                     f_gen.write(
                         f"  if((waddr >= {addr}) && (waddr < {addr + 2**addr_w})) begin\n"
                     )
-                    f_gen.write(f"    wready_int = {name}_ready_i;\n  end\n")
+                    f_gen.write(f"    wready_int = {name}_wready_i;\n  end\n")
 
         f_gen.write("  ready_nxt = (|iob_wstrb_i)? wready_int: rready_int;\n")
         f_gen.write("  rvalid_nxt = iob_rvalid_o;\n")
@@ -637,9 +649,7 @@ class mkregs:
         fswhdr.write("//Addresses\n")
         for row in table:
             name = row["name"]
-            if row["type"] == "W":
-                fswhdr.write(f"#define {core_prefix}{name} {row['addr']}\n")
-            if row["type"] == "R":
+            if "W" in row["type"] or "R" in row["type"]:
                 fswhdr.write(f"#define {core_prefix}{name} {row['addr']}\n")
 
         fswhdr.write("\n//Data widths (bit)\n")
@@ -649,9 +659,7 @@ class mkregs:
             n_bytes = int(self.bceil(n_bits, 3) / 8)
             if n_bytes == 3:
                 n_bytes = 4
-            if row["type"] == "W":
-                fswhdr.write(f"#define {core_prefix}{name}_W {n_bytes*8}\n")
-            if row["type"] == "R":
+            if "W" in row["type"] or "R" in row["type"]:
                 fswhdr.write(f"#define {core_prefix}{name}_W {n_bytes*8}\n")
 
         fswhdr.write("\n// Base Address\n")
@@ -666,7 +674,7 @@ class mkregs:
             if n_bytes == 3:
                 n_bytes = 4
             addr_w = self.calc_addr_w(log2n_items, n_bytes)
-            if row["type"] == "W":
+            if "W" in row["type"]:
                 sw_type = self.swreg_type(name, n_bytes)
                 addr_arg = ""
                 if addr_w / n_bytes > 1:
@@ -674,7 +682,7 @@ class mkregs:
                 fswhdr.write(
                     f"void {core_prefix}SET_{name}({sw_type} value{addr_arg});\n"
                 )
-            if row["type"] == "R":
+            if "R" in row["type"]:
                 sw_type = self.swreg_type(name, n_bytes)
                 addr_arg = ""
                 if addr_w / n_bytes > 1:
@@ -706,7 +714,7 @@ class mkregs:
             if n_bytes == 3:
                 n_bytes = 4
             addr_w = self.calc_addr_w(log2n_items, n_bytes)
-            if row["type"] == "W":
+            if "W" in row["type"]:
                 sw_type = self.swreg_type(name, n_bytes)
                 addr_arg = ""
                 addr_arg = ""
@@ -721,7 +729,7 @@ class mkregs:
                     f"  (*( (volatile {sw_type} *) ( (base) + ({core_prefix}{name}){addr_shift}) ) = (value));\n"
                 )
                 fsw.write("}\n\n")
-            if row["type"] == "R":
+            if "R" in row["type"]:
                 sw_type = self.swreg_type(name, n_bytes)
                 addr_arg = ""
                 addr_shift = ""
@@ -798,10 +806,10 @@ class mkregs:
                 self.check_alignment(addr, addr_w)
                 self.check_overlap(addr, addr_type, read_addr, write_addr)
                 addr_tmp = addr
-            elif addr_type == "R":  # auto address
+            elif "R" in addr_type:  # auto address
                 read_addr = self.bceil(read_addr, addr_w)
                 addr_tmp = read_addr
-            elif addr_type == "W":
+            elif "W" in addr_type:
                 write_addr = self.bceil(write_addr, addr_w)
                 addr_tmp = write_addr
             else:
@@ -817,9 +825,9 @@ class mkregs:
 
             # update addresses
             addr_tmp += 2**addr_w
-            if addr_type == "R":
+            if "R" in addr_type:
                 read_addr = addr_tmp
-            elif addr_type == "W":
+            elif "W" in addr_type:
                 write_addr = addr_tmp
             if not rw_overlap:
                 read_addr = addr_tmp

--- a/submodules/LIB/scripts/verilog_tools.py
+++ b/submodules/LIB/scripts/verilog_tools.py
@@ -130,3 +130,19 @@ def remove_verilog_line_from_source(verilog_code, verilog_file_path):
     # Write new system source file
     with open(verilog_file_path, "w") as system_source:
         system_source.writelines(lines)
+
+
+# Replace string in file
+def inplace_change(filename, old_string, new_string):
+    # Safely read the input filename using 'with'
+    with open(filename) as f:
+        s = f.read()
+        if old_string not in s:
+            print('"{old_string}" not found in {filename}.'.format(**locals()))
+            return
+
+    # Safely write the changed content, if found in the file
+    with open(filename, 'w') as f:
+        print('Changing "{old_string}" to "{new_string}" in {filename}'.format(**locals()))
+        s = s.replace(old_string, new_string)
+        f.write(s)

--- a/submodules/LIB/scripts/verilog_tools.py
+++ b/submodules/LIB/scripts/verilog_tools.py
@@ -142,7 +142,9 @@ def inplace_change(filename, old_string, new_string):
             return
 
     # Safely write the changed content, if found in the file
-    with open(filename, 'w') as f:
-        print('Changing "{old_string}" to "{new_string}" in {filename}'.format(**locals()))
+    with open(filename, "w") as f:
+        print(
+            'Changing "{old_string}" to "{new_string}" in {filename}'.format(**locals())
+        )
         s = s.replace(old_string, new_string)
         f.write(s)

--- a/submodules/UART/hardware/src/iob_uart.v
+++ b/submodules/UART/hardware/src/iob_uart.v
@@ -26,26 +26,25 @@ module iob_uart #(
    `include "iob_uart_swreg_inst.vs"
 
    // TXDATA Manual logic
-   wire [UART_DATA_W-1:0] TXDATA = iob_wdata_i[8*(`IOB_UART_TXDATA_ADDR%(DATA_W/8))+:UART_DATA_W];
-   assign TXDATA_ready  = 1'b1;
+   assign TXDATA_wready_wr  = 1'b1;
    
    // RXDATA Manual logic
-   assign RXDATA_ready  = 1'b1;
-   assign RXDATA_rvalid = 1'b1;
+   assign RXDATA_rready_rd  = 1'b1;
+   assign RXDATA_rvalid_rd = 1'b1;
 
    uart_core uart_core0 (
       .clk_i          (clk_i),
       .rst_i          (arst_i),
-      .rst_soft_i     (SOFTRESET),
-      .tx_en_i        (TXEN),
-      .rx_en_i        (RXEN),
-      .tx_ready_o     (TXREADY),
-      .rx_ready_o     (RXREADY),
-      .tx_data_i      (TXDATA),
-      .rx_data_o      (RXDATA),
-      .data_write_en_i(TXDATA_wen),
-      .data_read_en_i (RXDATA_ren),
-      .bit_duration_i (DIV),
+      .rst_soft_i     (SOFTRESET_wr),
+      .tx_en_i        (TXEN_wr),
+      .rx_en_i        (RXEN_wr),
+      .tx_ready_o     (TXREADY_rd),
+      .rx_ready_o     (RXREADY_rd),
+      .tx_data_i      (TXDATA_wdata_wr),
+      .rx_data_o      (RXDATA_rdata_rd),
+      .data_write_en_i(TXDATA_wen_wr),
+      .data_read_en_i (RXDATA_ren_rd),
+      .bit_duration_i (DIV_wr),
       .rxd_i          (rxd_i),
       .txd_o          (txd_o),
       .cts_i          (cts_i),

--- a/submodules/UART/iob_uart.py
+++ b/submodules/UART/iob_uart.py
@@ -122,7 +122,7 @@ class iob_uart(iob_module):
                         "rst_val": 0,
                         "addr": 0,
                         "log2n_items": 0,
-                        "autologic": True,
+                        "autoreg": True,
                         "descr": "Soft reset.",
                     },
                     {
@@ -132,7 +132,7 @@ class iob_uart(iob_module):
                         "rst_val": 0,
                         "addr": 2,
                         "log2n_items": 0,
-                        "autologic": True,
+                        "autoreg": True,
                         "descr": "Bit duration in system clock cycles.",
                     },
                     {
@@ -142,7 +142,7 @@ class iob_uart(iob_module):
                         "rst_val": 0,
                         "addr": 4,
                         "log2n_items": 0,
-                        "autologic": False,
+                        "autoreg": False,
                         "descr": "TX data.",
                     },
                     {
@@ -152,7 +152,7 @@ class iob_uart(iob_module):
                         "rst_val": 0,
                         "addr": 5,
                         "log2n_items": 0,
-                        "autologic": True,
+                        "autoreg": True,
                         "descr": "TX enable.",
                     },
                     {
@@ -162,7 +162,7 @@ class iob_uart(iob_module):
                         "rst_val": 0,
                         "addr": 6,
                         "log2n_items": 0,
-                        "autologic": True,
+                        "autoreg": True,
                         "descr": "RX enable.",
                     },
                     {
@@ -172,7 +172,7 @@ class iob_uart(iob_module):
                         "rst_val": 0,
                         "addr": 0,
                         "log2n_items": 0,
-                        "autologic": True,
+                        "autoreg": True,
                         "descr": "TX ready to receive data.",
                     },
                     {
@@ -182,7 +182,7 @@ class iob_uart(iob_module):
                         "rst_val": 0,
                         "addr": 1,
                         "log2n_items": 0,
-                        "autologic": True,
+                        "autoreg": True,
                         "descr": "RX data is ready to be read.",
                     },
                     # NOTE: RXDATA needs to be the only Read register in a CPU Word
@@ -194,7 +194,7 @@ class iob_uart(iob_module):
                         "rst_val": 0,
                         "addr": 4,
                         "log2n_items": 0,
-                        "autologic": False,
+                        "autoreg": False,
                         "descr": "RX data.",
                     },
                 ],


### PR DESCRIPTION
### IOb-SoC changes:
- Fix `ext_mem0` connections to `axi_m_port` bus.
- Fix regex expression in `iob_soc_create_system.py`.
- Update submodules with changes from LIB.
### LIB changes (original PR: https://github.com/IObundle/iob-lib/pull/683):
- Add support for `RW` register type in `mkregs.py`. 
- Rename `autologic` to `autoreg` in the fields of the `regs` dictionary.
- Add `_rd` and `_wr` suffixes to wires generated by `mkregs.py`, corresponding to the register type `R` or `W`, respectively.
- Rename generated `ready` signals (generated by `autoreg=False`) to end in either `_rready_rd` or `_wready_wr`.

Example `iob_uart_swreg_inst.vs` currently generated by `mkregs.py`:
```
   wire [                                    1-1:0] SOFTRESET_wr;
   wire [                                   16-1:0] DIV_wr;
   wire [((UART_DATA_W > 1) ? UART_DATA_W : 1)-1:0] TXDATA_wdata_wr;
   wire                                             TXDATA_wen_wr;
   wire                                             TXDATA_wready_wr;
   wire [                                    1-1:0] TXEN_wr;
   wire [                                    1-1:0] RXEN_wr;
   wire [                                    1-1:0] TXREADY_rd;
   wire [                                    1-1:0] RXREADY_rd;
   wire [((UART_DATA_W > 1) ? UART_DATA_W : 1)-1:0] RXDATA_rdata_rd;
   wire                                             RXDATA_ren_rd;
   wire                                             RXDATA_rvalid_rd;
   wire                                             RXDATA_rready_rd;

   iob_uart_swreg_gen #(

      .DATA_W     (DATA_W),
      .ADDR_W     (ADDR_W),
      .UART_DATA_W(UART_DATA_W)

   ) swreg_0 (
      .SOFTRESET_o     (SOFTRESET_wr),
      .DIV_o           (DIV_wr),
      .TXDATA_wdata_o  (TXDATA_wdata_wr),
      .TXDATA_wen_o    (TXDATA_wen_wr),
      .TXDATA_wready_i (TXDATA_wready_wr),
      .TXEN_o          (TXEN_wr),
      .RXEN_o          (RXEN_wr),
      .TXREADY_i       (TXREADY_rd),
      .RXREADY_i       (RXREADY_rd),
      .RXDATA_rdata_i  (RXDATA_rdata_rd),
      .RXDATA_ren_o    (RXDATA_ren_rd),
      .RXDATA_rvalid_i (RXDATA_rvalid_rd),
      .RXDATA_rready_i (RXDATA_rready_rd),
      .iob_ready_nxt_o (iob_ready_nxt_o),
      .iob_rvalid_nxt_o(iob_rvalid_nxt_o),
      .iob_avalid_i    (iob_avalid_i),      //Request valid.
      .iob_addr_i      (iob_addr_i),        //Address.
      .iob_wdata_i     (iob_wdata_i),       //Write data.
      .iob_wstrb_i     (iob_wstrb_i),       //Write strobe.
      .iob_rvalid_o    (iob_rvalid_o),      //Read data valid.
      .iob_rdata_o     (iob_rdata_o),       //Read data.
      .iob_ready_o     (iob_ready_o),       //Interface ready.
      .clk_i           (clk_i),
      .cke_i           (cke_i),
      .arst_i          (arst_i)

   );
```
### UART changes (original PR: https://github.com/IObundle/iob-uart/pull/189):
- Add `_rd` and `_wr` register suffixes.