### PR TITLE
fix(quartus): run `timing.tcl` once, report names

### DIFF
--- a/submodules/LIB/hardware/fpga/quartus/build.tcl
+++ b/submodules/LIB/hardware/fpga/quartus/build.tcl
@@ -126,7 +126,7 @@ if {[catch {execute_module -tool fit} result]} {
 }
 
 #run quartus sta
-if {[catch {execute_module -tool sta -args "--report_script=quartus/timing.tcl"} result]} {
+if {[catch {execute_module -tool sta} result]} {
     puts "\nResult: $result\n"
     puts "ERROR: STA failed. See report files.\n"
     qexit -error

--- a/submodules/LIB/hardware/fpga/quartus/timing.tcl
+++ b/submodules/LIB/hardware/fpga/quartus/timing.tcl
@@ -5,7 +5,7 @@ create_timing_netlist
 read_sdc
 update_timing_netlist
 
-report_path -nworst 5 -multi_corner -file reports/$NAME.sta.paths
+report_path -nworst 3 -multi_corner -file reports/$NAME.sta.paths
 report_path -min_path -file reports/$NAME.sta.min_path
 report_max_skew -file reports/$NAME.sta.skew
 report_metastability -file reports/$NAME.sta.metastability
@@ -15,9 +15,9 @@ set setup_domain_list [get_clock_domain_info -setup]
 # Report the Worst Case Setups slacks per clock
 foreach domain $setup_domain_list {
     # replace space with '_'
-    set domain_name [string map {" " "_" } $domain]
-    report_timing -nworst 5 -setup -to_clock [lindex $domain 0] -file reports/$NAME.$domain_name.setup.sta.timing
-    report_timing -nworst 5 -hold -to_clock [lindex $domain 0] -file reports/$NAME.$domain_name.hold.sta.timing
+    set domain_name [lindex $domain 0]
+    report_timing -nworst 3 -setup -to_clock $domain_name -file reports/$NAME.$domain_name.setup.sta.timing
+    report_timing -nworst 3 -hold -to_clock $domain_name -file reports/$NAME.$domain_name.hold.sta.timing
 }
 
 catch {delete_timing_netlist}


### PR DESCRIPTION
- update quartus `build.tcl` to run `timing.tcl` once after static timing analysis
- improve clock domain specific setup and hold report names