### PR TITLE
Allow override of `N_SLAVES` macro by subclasses; Update `axi_m_port` part select script. 

### DIFF
--- a/iob_soc.py
+++ b/iob_soc.py
@@ -61,8 +61,8 @@ class iob_soc(iob_module):
         if num_extmem_connections == 1:
             inplace_change(
                 os.path.join(cls.build_dir, "hardware/src", cls.name + ".v"),
-                "[0+:1])",
-                ")",
+                "[0+:1]",
+                "",
             )
         # Generate hw, sw, doc files
         super()._generate_files()

--- a/scripts/iob_soc_utils.py
+++ b/scripts/iob_soc_utils.py
@@ -241,7 +241,7 @@ def post_setup_iob_soc(python_module, num_extmem_connections):
             )
         # Copy joinHexFiles.py from LIB
         build_srcs.copy_files(
-            "submodules/LIB", f"{build_dir}/scripts", ["joinHexFiles.py"], "*.py"
+            build_srcs.LIB_DIR, f"{build_dir}/scripts", ["joinHexFiles.py"], "*.py"
         )
 
 

--- a/submodules/LIB/scripts/submodule_utils.py
+++ b/submodules/LIB/scripts/submodule_utils.py
@@ -136,27 +136,30 @@ def get_peripheral_macros(confs, peripherals_list):
     # Append macros with ID of each peripheral
     confs.extend(get_periphs_id_as_macros(peripherals_list))
     # Append macro with number of peripherals
-    confs.append(
-        {
-            "name": "N_SLAVES",
-            "type": "M",
-            "val": get_n_periphs(peripherals_list),
-            "min": "NA",
-            "max": "NA",
-            "descr": "Number of peripherals",
-        }
-    )
-    # Append macro with width of peripheral bus
-    confs.append(
-        {
-            "name": "N_SLAVES_W",
-            "type": "M",
-            "val": get_n_periphs_w(peripherals_list),
-            "min": "NA",
-            "max": "NA",
-            "descr": "Peripheral bus width",
-        }
-    )
+    # Only append macro if it does not exist (to allow subclasses set their own number)
+    if not list([i for i in confs if i["name"] == "N_SLAVES"]):
+        confs.append(
+            {
+                "name": "N_SLAVES",
+                "type": "M",
+                "val": get_n_periphs(peripherals_list),
+                "min": "NA",
+                "max": "NA",
+                "descr": "Number of peripherals",
+            }
+        )
+    if not list([i for i in confs if i["name"] == "N_SLAVES_W"]):
+        # Append macro with width of peripheral bus
+        confs.append(
+            {
+                "name": "N_SLAVES_W",
+                "type": "M",
+                "val": get_n_periphs_w(peripherals_list),
+                "min": "NA",
+                "max": "NA",
+                "descr": "Peripheral bus width",
+            }
+        )
 
 
 # Check if a module of certain type is in given modules list.


### PR DESCRIPTION
Update python scripts to give more flexibility to subclasses (OpenCryptoLinux):
- Allow subclasses to override the `N_SLAVES` and `N_SLAVES_W` macros;
- Update expression for the `axi_m_port` signals part select. The new expression also replaces code in the subclasses.