### PR TITLE
fix(SWREG): <SWREG>_ADDR as macro address; remove unused <SWREG>_rvalikd_rd signal

### DIFF
--- a/hardware/simulation/src/iob_soc_tb.cpp
+++ b/hardware/simulation/src/iob_soc_tb.cpp
@@ -69,13 +69,13 @@ void uartread(unsigned int cpu_address, char *read_reg) {
 
 void inituart() {
   // pulse reset uart
-  uartwrite(IOB_UART_SOFTRESET, 1, IOB_UART_SOFTRESET_W / 8);
-  uartwrite(IOB_UART_SOFTRESET, 0, IOB_UART_SOFTRESET_W / 8);
+  uartwrite(IOB_UART_SOFTRESET_ADDR, 1, IOB_UART_SOFTRESET_W / 8);
+  uartwrite(IOB_UART_SOFTRESET_ADDR, 0, IOB_UART_SOFTRESET_W / 8);
   // config uart div factor
-  uartwrite(IOB_UART_DIV, int(FREQ / BAUD), IOB_UART_DIV_W / 8);
+  uartwrite(IOB_UART_DIV_ADDR, int(FREQ / BAUD), IOB_UART_DIV_W / 8);
   // enable uart for receiving
-  uartwrite(IOB_UART_RXEN, 1, IOB_UART_RXEN_W / 8);
-  uartwrite(IOB_UART_TXEN, 1, IOB_UART_TXEN_W / 8);
+  uartwrite(IOB_UART_RXEN_ADDR, 1, IOB_UART_RXEN_W / 8);
+  uartwrite(IOB_UART_TXEN_ADDR, 1, IOB_UART_TXEN_W / 8);
 }
 
 int main(int argc, char **argv, char **env) {
@@ -123,15 +123,15 @@ int main(int argc, char **argv, char **env) {
       break;
     }
     while (!rxread_reg && !txread_reg) {
-      uartread(IOB_UART_RXREADY, &rxread_reg);
-      uartread(IOB_UART_TXREADY, &txread_reg);
+      uartread(IOB_UART_RXREADY_ADDR, &rxread_reg);
+      uartread(IOB_UART_TXREADY_ADDR, &txread_reg);
     }
     if (rxread_reg) {
       if ((soc2cnsl_fd = fopen("./soc2cnsl", "rb")) != NULL) {
         able2read = fread(&cpu_char, sizeof(char), 1, soc2cnsl_fd);
         if (able2read == 0) {
           fclose(soc2cnsl_fd);
-          uartread(IOB_UART_RXDATA, &cpu_char);
+          uartread(IOB_UART_RXDATA_ADDR, &cpu_char);
           soc2cnsl_fd = fopen("./soc2cnsl", "wb");
           fwrite(&cpu_char, sizeof(char), 1, soc2cnsl_fd);
           rxread_reg = 0;
@@ -145,7 +145,7 @@ int main(int argc, char **argv, char **env) {
       }
       able2write = fread(&cpu_char, sizeof(char), 1, cnsl2soc_fd);
       if (able2write > 0) {
-        uartwrite(IOB_UART_TXDATA, cpu_char, IOB_UART_TXDATA_W / 8);
+        uartwrite(IOB_UART_TXDATA_ADDR, cpu_char, IOB_UART_TXDATA_W / 8);
         fclose(cnsl2soc_fd);
         cnsl2soc_fd = fopen("./cnsl2soc", "w");
       }

--- a/software/src/iob_soc_boot.c
+++ b/software/src/iob_soc_boot.c
@@ -75,7 +75,7 @@ int main() {
   uart_txwait();
 
 #ifdef USE_EXTMEM
-  while (!cache_wtb_empty())
+  while (!IOB_CACHE_GET_WTB_EMPTY())
     ;
 #endif
 }

--- a/submodules/LIB/scripts/mkregs.py
+++ b/submodules/LIB/scripts/mkregs.py
@@ -529,12 +529,13 @@ class mkregs:
 
         # iob_rvalid_nxt output
         f_gen.write("//iob_rvalid_nxt output\n")
-        f_gen.write("assign iob_rvalid_nxt_o = iob_avalid_i & iob_ready_o & (!iob_wstrb_i);\n\n")
-        
+        f_gen.write(
+            "assign iob_rvalid_nxt_o = iob_avalid_i & iob_ready_o & (!iob_wstrb_i);\n\n"
+        )
+
         # iob_rdata_o output
         f_gen.write("assign iob_rdata_o = rdata_int;\n\n")
-        
-        
+
         f_gen.write("endmodule\n")
         f_gen.close()
         f_inst.close()
@@ -630,7 +631,7 @@ class mkregs:
         for row in table:
             name = row["name"]
             if "W" in row["type"] or "R" in row["type"]:
-                fswhdr.write(f"#define {core_prefix}{name} {row['addr']}\n")
+                fswhdr.write(f"#define {core_prefix}{name}_ADDR {row['addr']}\n")
 
         fswhdr.write("\n//Data widths (bit)\n")
         for row in table:
@@ -706,7 +707,7 @@ class mkregs:
                     f"void {core_prefix}SET_{name}({sw_type} value{addr_arg}) {{\n"
                 )
                 fsw.write(
-                    f"  (*( (volatile {sw_type} *) ( (base) + ({core_prefix}{name}){addr_shift}) ) = (value));\n"
+                    f"  (*( (volatile {sw_type} *) ( (base) + ({core_prefix}{name}_ADDR){addr_shift}) ) = (value));\n"
                 )
                 fsw.write("}\n\n")
             if "R" in row["type"]:
@@ -718,7 +719,7 @@ class mkregs:
                     addr_shift = f" + (addr << {int(log(n_bytes, 2))})"
                 fsw.write(f"{sw_type} {core_prefix}GET_{name}({addr_arg}) {{\n")
                 fsw.write(
-                    f"  return (*( (volatile {sw_type} *) ( (base) + ({core_prefix}{name}){addr_shift}) ));\n"
+                    f"  return (*( (volatile {sw_type} *) ( (base) + ({core_prefix}{name}_ADDR){addr_shift}) ));\n"
                 )
                 fsw.write("}\n\n")
         fsw.close()

--- a/submodules/UART/hardware/src/iob_uart.v
+++ b/submodules/UART/hardware/src/iob_uart.v
@@ -30,7 +30,6 @@ module iob_uart #(
    
    // RXDATA Manual logic
    assign RXDATA_rready_rd  = 1'b1;
-   assign RXDATA_rvalid_rd = 1'b1;
 
    uart_core uart_core0 (
       .clk_i          (clk_i),


### PR DESCRIPTION
- update software macro addresses for software accessible registers to
  have `_ADDR` sufix
- remove unused SWREG_rvalid_rd signal. Now swreg module generates
  rvalid signal for all software accessible registers
- Addresses #618 