### PR TITLE
[BREAKING] Add core name prefix to `*_conf.h` macros.

### DIFF
--- a/scripts/iob_soc_create_periphs_tmp.py
+++ b/scripts/iob_soc_create_periphs_tmp.py
@@ -10,7 +10,7 @@ from submodule_utils import *
 # Arguments:
 #   periph_addr_select_bit: Adress selection bit (P variable)
 #   peripherals_list: list with amount of instances of each peripheral (returned by get_peripherals())
-def create_periphs_tmp(addr_w, peripherals_list, out_file):
+def create_periphs_tmp(name, addr_w, peripherals_list, out_file):
     # Don't override output file
     if os.path.isfile(out_file):
         return
@@ -18,9 +18,7 @@ def create_periphs_tmp(addr_w, peripherals_list, out_file):
     template_contents = []
     for instance in peripherals_list:
         template_contents.extend(
-            "#define {}_BASE ({}<<({}-1-N_SLAVES_W))\n".format(
-                instance.name, instance.name, addr_w
-            )
+            f"#define {instance.name}_BASE ({name.upper()}_{instance.name}<<({addr_w}-1-{name.upper()}_N_SLAVES_W))\n"
         )
 
     # Write system.v

--- a/scripts/iob_soc_utils.py
+++ b/scripts/iob_soc_utils.py
@@ -35,6 +35,7 @@ def iob_soc_sw_setup(python_module, exclude_files=[]):
     # Build periphs_tmp.h
     if peripherals_list:
         create_periphs_tmp(
+            python_module.name,
             next(i["val"] for i in confs if i["name"] == "ADDR_W"),
             peripherals_list,
             f"{build_dir}/software/{name}_periphs.h",

--- a/software/src/iob_soc_boot.S
+++ b/software/src/iob_soc_boot.S
@@ -5,8 +5,8 @@
 .global main
 
 //set stack pointer
-lui sp, %hi(1<<SRAM_ADDR_W)
-addi sp, sp, %lo(1<<SRAM_ADDR_W)
+lui sp, %hi(1<<IOB_SOC_SRAM_ADDR_W)
+addi sp, sp, %lo(1<<IOB_SOC_SRAM_ADDR_W)
 
 //call main
 jal ra, main

--- a/software/src/iob_soc_boot.c
+++ b/software/src/iob_soc_boot.c
@@ -19,7 +19,7 @@ int main() {
   uart_init(UART_BASE, FREQ / BAUD);
 
 #ifdef IOB_SOC_USE_EXTMEM
-  cache_init(1 << E, MEM_ADDR_W);
+  cache_init(1 << IOB_SOC_E, IOB_SOC_MEM_ADDR_W);
 #endif
 
   // connect with console

--- a/software/src/iob_soc_boot.c
+++ b/software/src/iob_soc_boot.c
@@ -3,13 +3,13 @@
 #include "iob_soc_conf.h"
 #include "iob_soc_system.h"
 
-#ifdef USE_EXTMEM
+#ifdef IOB_SOC_USE_EXTMEM
 #include "iob-cache.h"
 #endif
 
 // defined here (and not in periphs.h) because it is the only peripheral used
 // by the bootloader
-#define UART_BASE (UART0 << (31 - N_SLAVES_W))
+#define UART_BASE (IOB_SOC_UART0 << (31 - IOB_SOC_N_SLAVES_W))
 
 #define PROGNAME "IOb-Bootloader"
 
@@ -18,7 +18,7 @@ int main() {
   // init uart
   uart_init(UART_BASE, FREQ / BAUD);
 
-#ifdef USE_EXTMEM
+#ifdef IOB_SOC_USE_EXTMEM
   cache_init(1 << E, MEM_ADDR_W);
 #endif
 
@@ -32,17 +32,17 @@ int main() {
   uart_puts(PROGNAME);
   uart_puts(": connected!\n");
 
-#ifdef USE_EXTMEM
+#ifdef IOB_SOC_USE_EXTMEM
   uart_puts(PROGNAME);
   uart_puts(": DDR in use and program runs from DDR\n");
 #endif
 
   // address to copy firmware to
   char *prog_start_addr;
-#ifdef USE_EXTMEM
+#ifdef IOB_SOC_USE_EXTMEM
   prog_start_addr = (char *)EXTRA_BASE;
 #else
-  prog_start_addr = (char *)(1 << BOOTROM_ADDR_W);
+  prog_start_addr = (char *)(1 << IOB_SOC_BOOTROM_ADDR_W);
 #endif
 
   while (uart_getc() != ACK) {
@@ -50,7 +50,7 @@ int main() {
     uart_puts(": Waiting for Console ACK.\n");
   }
 
-#ifndef INIT_MEM
+#ifndef IOB_SOC_INIT_MEM
   // receive firmware from host
   int file_size = 0;
   char r_fw[] = "iob_soc_firmware.bin";
@@ -74,7 +74,7 @@ int main() {
   uart_puts(": Restart CPU to run user program...\n");
   uart_txwait();
 
-#ifdef USE_EXTMEM
+#ifdef IOB_SOC_USE_EXTMEM
   while (!IOB_CACHE_GET_WTB_EMPTY())
     ;
 #endif

--- a/software/src/iob_soc_firmware.S
+++ b/software/src/iob_soc_firmware.S
@@ -5,12 +5,12 @@
 .global main
 
 //set stack pointer
-#ifdef USE_EXTMEM //need to set MSB to address external memory
-lui sp, %hi(EXTRA_BASE | 1<<SRAM_ADDR_W)
-addi sp, sp, %lo(EXTRA_BASE | 1<<SRAM_ADDR_W)
+#ifdef IOB_SOC_USE_EXTMEM //need to set MSB to address external memory
+lui sp, %hi(EXTRA_BASE | 1<<IOB_SOC_SRAM_ADDR_W)
+addi sp, sp, %lo(EXTRA_BASE | 1<<IOB_SOC_SRAM_ADDR_W)
 #else
-lui sp, %hi(1<<SRAM_ADDR_W)
-addi sp, sp, %lo(1<<SRAM_ADDR_W)
+lui sp, %hi(1<<IOB_SOC_SRAM_ADDR_W)
+addi sp, sp, %lo(1<<IOB_SOC_SRAM_ADDR_W)
 #endif
 
 //call main

--- a/software/src/iob_soc_firmware.c
+++ b/software/src/iob_soc_firmware.c
@@ -77,7 +77,7 @@ int main() {
   free(sendfile);
   free(recvfile);
 
-  // #ifdef USE_EXTMEM
+  // #ifdef IOB_SOC_USE_EXTMEM
   //   if(memory_access_failed)
   //       uart_sendfile("test.log", iob_strlen(fail_string), fail_string);
   //       uart_finish();

--- a/software/src/iob_soc_system.h
+++ b/software/src/iob_soc_system.h
@@ -1,6 +1,6 @@
 // extra memory base address
 // extra memory is SRAM if running from DDR or DDR if running from SRAM
-#define EXTRA_BASE (1 << E)
+#define EXTRA_BASE (1 << IOB_SOC_E)
 
 // boot controller base address
-#define BOOTCTR_BASE (1 << B)
+#define BOOTCTR_BASE (1 << IOB_SOC_B)

--- a/submodules/LIB/scripts/mk_configuration.py
+++ b/submodules/LIB/scripts/mk_configuration.py
@@ -73,11 +73,11 @@ def conf_h(macros, top_module, out_dir):
             # Replace any Verilog specific syntax by equivalent C syntax
             m_default_val = re.sub("\d+'h", "0x", str(macro["val"]))
             file2create.write(
-                f"#define {m_name} {str(m_default_val).replace('`','')}\n"
+                f"#define {core_prefix}{m_name} {str(m_default_val).replace('`','')}\n"
             )  # Remove Verilog macros ('`')
         elif macro["val"]:
             m_name = macro["name"].upper()
-            file2create.write(f"#define {m_name} 1\n")
+            file2create.write(f"#define {core_prefix}{m_name} 1\n")
     file2create.write(f"\n#endif // H_{fname}_H\n")
 
     file2create.close()

--- a/submodules/LIB/scripts/mk_configuration.py
+++ b/submodules/LIB/scripts/mk_configuration.py
@@ -72,8 +72,16 @@ def conf_h(macros, top_module, out_dir):
             m_name = macro["name"].upper()
             # Replace any Verilog specific syntax by equivalent C syntax
             m_default_val = re.sub("\d+'h", "0x", str(macro["val"]))
+            m_min_val = re.sub("\d+'h", "0x", str(macro["min"]))
+            m_max_val = re.sub("\d+'h", "0x", str(macro["max"]))
             file2create.write(
                 f"#define {core_prefix}{m_name} {str(m_default_val).replace('`','')}\n"
+            )  # Remove Verilog macros ('`')
+            file2create.write(
+                f"#define {core_prefix}{m_name}_MIN {str(m_min_val).replace('`','')}\n"
+            )  # Remove Verilog macros ('`')
+            file2create.write(
+                f"#define {core_prefix}{m_name}_MAX {str(m_max_val).replace('`','')}\n"
             )  # Remove Verilog macros ('`')
         elif macro["val"]:
             m_name = macro["name"].upper()


### PR DESCRIPTION
Add a core name prefix to every macro in the generated `*_conf.h` file. This allows us to include this file in the system's firmware while avoiding duplicate macros from different cores.

Note: This PR may break drivers of cores that have not yet added the new prefix to their macros.

This resolves https://github.com/IObundle/iob-soc/issues/626