### PR TITLE
fix(axil2iob): register axil_bvalid_nxt

### DIFF
--- a/submodules/LIB/hardware/modules/axil2iob/hardware/src/axil2iob.v
+++ b/submodules/LIB/hardware/modules/axil2iob/hardware/src/axil2iob.v
@@ -54,7 +54,7 @@ module axil2iob #(
       .clk_i (clk_i),
       .arst_i(arst_i),
       .cke_i (cke_i),
-      .data_i(axil_wvalid_i),
+      .data_i(axil_bvalid_nxt),
       .data_o(axil_bvalid_o)
   );
 


### PR DESCRIPTION
- axil2iob registers axil_bvalid_nxt as axil_bvalid_o