### PR TITLE
fix(sw): check USE_EXTMEM variable

### DIFF
--- a/software/sw_build.mk
+++ b/software/sw_build.mk
@@ -15,7 +15,7 @@ iob_soc_boot.hex: ../../software/iob_soc_boot.bin
 	../../scripts/makehex.py $< $(call GET_IOB_SOC_CONF_MACRO,BOOTROM_ADDR_W) > $@
 
 iob_soc_firmware.hex: iob_soc_firmware.bin
-ifdef USE_EXTMEM
+ifeq ($(USE_EXTMEM),1)
 	../../scripts/makehex.py $< $(call GET_IOB_SOC_CONF_MACRO,MEM_ADDR_W) > $@
 else
 	../../scripts/makehex.py $< $(call GET_IOB_SOC_CONF_MACRO,SRAM_ADDR_W) > $@


### PR DESCRIPTION
- check USE_EXTMEM variable instead of just checking if variable exists. Fixes case where USE_EXTMEM=0 and firmware.hex is generated with MEM_ADDR_W size