### PR TITLE
feat(ethernet): Remove PHY reset logic from wrappers.

### DIFF
--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_fpga_wrapper.v
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_fpga_wrapper.v
@@ -98,27 +98,10 @@ module iob_soc_fpga_wrapper (
    assign ENET_TX_EN = ETH0_MTxEn;
    //assign ENET_TX_ERR = ETH0_MTxErr;
 
+   assign ENET_RESETN = ETH0_phy_rstn_o;
+
    assign ETH0_MColl = 1'b0;
    assign ETH0_MCrS = 1'b0;
-
-   //
-   //  PHY RESET
-   //
-   // TODO: Reset PHY using `MDIO` commands, instead of a dedicated reset
-   // signal.
-   reg [20-1:0] phy_rst_cnt;
-   reg ETH_PHY_RESETN;
-
-   localparam PHY_RST_CNT = 20'hFFFFF;
-
-   always @(posedge clk, posedge arst)
-      if (arst) begin
-         phy_rst_cnt    <= 0;
-         ETH_PHY_RESETN <= 0;
-      end else if (phy_rst_cnt != PHY_RST_CNT) phy_rst_cnt <= phy_rst_cnt + 1'b1;
-      else ETH_PHY_RESETN <= 1;
-
-   assign ENET_RESETN = ETH_PHY_RESETN;
 `endif
 
    //

--- a/hardware/fpga/vivado/AES-KU040-DB-G/iob_soc_fpga_wrapper.v
+++ b/hardware/fpga/vivado/AES-KU040-DB-G/iob_soc_fpga_wrapper.v
@@ -94,27 +94,10 @@ module iob_soc_fpga_wrapper (
    assign ENET_TX_EN = ETH0_MTxEn;
    //assign ENET_TX_ERR = ETH0_MTxErr;
 
+   assign ENET_RESETN = ETH0_phy_rstn_o;
+
    assign ETH0_MColl = 1'b0;
    assign ETH0_MCrS = 1'b0;
-   
-   //
-   //  PHY RESET
-   //
-   // TODO: Reset PHY using `MDIO` commands, instead of a dedicated reset
-   // signal.
-   reg [20-1:0] phy_rst_cnt;
-   reg ETH_PHY_RESETN;
-
-   localparam PHY_RST_CNT = 20'hFFFFF;
-
-   always @(posedge clk, posedge arst)
-      if (arst) begin
-         phy_rst_cnt    <= 0;
-         ETH_PHY_RESETN <= 0;
-      end else if (phy_rst_cnt != PHY_RST_CNT) phy_rst_cnt <= phy_rst_cnt + 1'b1;
-      else ETH_PHY_RESETN <= 1;
-
-   assign ENET_RESETN = ETH_PHY_RESETN;
 `endif
 
 

--- a/scripts/iob_soc_create_wrapper_files.py
+++ b/scripts/iob_soc_create_wrapper_files.py
@@ -196,7 +196,7 @@ def create_ku040_rstn(out_dir, name, num_extmem_connections):
     rstn_str = rstn_str[:-3]
 
     file_str = f"      wire [{num_extmem_connections}-1:0] rstn;"
-    file_str += f"      assign arst ={rstn_str};"
+    file_str += f"      assign arst ={rstn_str};" # FIXME: This is probably wrong. Reset signals should not have logic
 
     fp_rstn = open(f"{out_dir}/{name}_ku040_rstn.vs", "w")
     fp_rstn.write(file_str)


### PR DESCRIPTION
PHY reset logic is now handled by the iob-eth core.