### PR TITLE
added caravel_user_project as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "submodules/AXI"]
 	path = submodules/AXI
 	url = git@github.com:IObundle/verilog-axi.git
+[submodule "submodules/caravel_user_project"]
+	path = submodules/caravel_user_project
+	url = https://github.com/efabless/caravel_user_project

--- a/Makefile
+++ b/Makefile
@@ -71,3 +71,18 @@ board_server_status:
 	systemctl status board_server
 
 .PHONY: setup sim-test fpga-test doc-test test-all board_server_install board_server_uninstall board_server_status
+
+
+
+
+
+
+#test caravel 
+
+Caravel_DIR := submodules/caravel_user_project #directory to caravel
+First_script := submodules/LIB/scripts # directory to the python script
+
+
+caravel-build:
+	python3 $(First_script)/caravel_setup.py 
+	make setup -C $(Caravel_DIR) -j1 build

--- a/hardware/caravel/src/iob_counter.v
+++ b/hardware/caravel/src/iob_counter.v
@@ -1,0 +1,37 @@
+`timescale 1ns / 1ps
+
+module iob_counter #(
+    parameter BITS = 32,
+    parameter rst_val = {BITS{1'b0}}
+    ) (
+    //`include "clk_en_rst_s_port.vs"
+    input rst,
+    input en_i,
+    input clk,
+    input [BITS-1:0] Data_write,
+    input Data_write_enb,
+    output [BITS-1:0] data_o
+    );
+    reg [BITS-1:0] data;
+    always @(posedge clk)begin
+        if(Data_write_enb ==1'b1)begin
+            data <= Data_write;
+        end
+        else if (en_i == 1'b1) begin
+            data <= data_o + 1'b1;
+        end
+        else begin
+            data <= data_o;
+        end
+    end
+    iob_reg #(
+        .BITS(BITS),
+        .rst_val(rst_val)
+     ) reg0 (
+        //`include "clk_en_rst_s_s_portmap.vs"
+        .clk(clk),
+        .rst(rst),
+        .data_i(data),
+        .data_out(data_o)
+        );
+endmodule

--- a/hardware/caravel/src/iob_reg.v
+++ b/hardware/caravel/src/iob_reg.v
@@ -1,0 +1,22 @@
+`timescale 1ns / 1ps
+
+module iob_reg #(
+    parameter BITS = 32,
+    parameter rst_val = {BITS{1'b0}}
+)(
+    input [BITS-1:0] data_i,
+    input clk,
+    input rst,
+    output reg [BITS-1:0] data_out
+);
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            data_out <= rst_val;
+        end 
+        else begin
+            data_out <= data_i;
+    end
+    end
+endmodule
+
+`default_nettype wire

--- a/hardware/caravel/src/iob_soc_test.v
+++ b/hardware/caravel/src/iob_soc_test.v
@@ -1,0 +1,111 @@
+`timescale 1ns / 1ps
+
+// SPDX-FileCopyrightText: 2020 Efabless Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
+
+`default_nettype none
+/*
+ *-------------------------------------------------------------
+ *
+ * user_proj_example
+ *
+ * This is an example of a (trivially simple) user project,
+ * showing how the user project can connect to the logic
+ * analyzer, the wishbone bus, and the I/O pads.
+ *
+ * This project generates an integer count, which is output
+ * on the user area GPIO pads (digital output only).  The
+ * wishbone connection allows the project to be controlled
+ * (start and stop) from the management SoC program.
+ *
+ * See the testbenches in directory "mprj_counter" for the
+ * example programs that drive this user project.  The three
+ * testbenches are "io_ports", "la_test1", and "la_test2".
+ *
+ *-------------------------------------------------------------
+ */
+
+module iob_soc_test #(
+    parameter BITS = 16
+)(
+`ifdef USE_POWER_PINS
+    inout vccd1,	// User area 1 1.8V supply
+    inout vssd1,	// User area 1 digital ground
+`endif
+
+    // Wishbone Slave ports (WB MI A)
+    input wb_clk_i,
+    input wb_rst_i,
+    input wbs_stb_i,
+    input wbs_cyc_i,
+    input wbs_we_i,
+    input [3:0] wbs_sel_i,
+    input [31:0] wbs_dat_i,
+    input [31:0] wbs_adr_i,
+    output wbs_ack_o,
+    output [31:0] wbs_dat_o,
+
+    // Logic Analyzer Signals
+    input  [127:0] la_data_in,
+    output [127:0] la_data_out,
+    input  [127:0] la_oenb,
+
+    // IOs
+    input  [BITS-1:0] io_in,
+    output [BITS-1:0] io_out,
+    output [BITS-1:0] io_oeb,
+
+    // IRQ
+    output [2:0] irq
+);
+    wire clk;
+    wire rst;
+
+
+
+    wire [32-1:0] write, data_out; 
+    wire en_i;
+    wire en_write;
+    assign wbs_dat_o=0;
+    assign io_oeb =0;
+    assign io_out = 0;
+    assign irq = 0;
+    assign la_data_out[127:64] = 0;
+    assign la_data_out[31:0] = 0;
+    assign wbs_ack_o = 0;
+
+    // Assuming LA probes [65:64] are for controlling the count clk & reset  
+    assign write = la_data_in[32-1:0];
+    assign en_i = la_oenb[127];
+    assign en_write = ~la_oenb[0];
+    assign la_data_out[63:32] = data_out;
+
+    assign clk = (~la_oenb[64]) ? la_data_in[64]: wb_clk_i;
+    assign rst = (~la_oenb[65]) ? la_data_in[65]: wb_rst_i;
+    parameter rst_val = {32{1'b0}};
+
+
+    iob_counter CNT(
+        .rst(rst),
+        .clk(clk),
+        .en_i(en_i),
+        .Data_write_enb(en_write),
+        .Data_write(write),
+        .data_o(data_out)
+    );
+
+endmodule
+
+`default_nettype wire

--- a/submodules/LIB/scripts/caravel_setup.py
+++ b/submodules/LIB/scripts/caravel_setup.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import re
+
+
+to_caravel_make = "submodules/caravel_user_project/Makefile" #path to caravel MAKEFILE
+to_caravel= "submodules/caravel_user_project" #path to caravel
+current_directory = os.getcwd() # get current directory
+
+Full_Path_to_caravel = os.path.join(current_directory, to_caravel) #full caravel path
+Full_path_to_caravel_Make = os.path.join(current_directory, to_caravel_make) #full makefile caravel path
+
+
+line_to_add = "export PWD := " + Full_Path_to_caravel + "\n" #For some reason the PWD is not exported in my makefile
+
+
+#part that exports the PWD in the make file
+with open(Full_path_to_caravel_Make, 'r') as file:
+    content = file.read()
+pattern = r'(?m)^SIM\?\=RTL\n(.*)$'
+updated_content = re.sub(pattern, r'SIM?=RTL\n' + line_to_add, content)
+with open(Full_path_to_caravel_Make, 'w') as file:
+    file.write(updated_content)
+
+
+
+with open(Full_path_to_caravel_Make, 'r') as file:
+    content = file.read()
+# Replace CARAVEL_LITE?=1 with CARAVEL_LITE?=0
+content = re.sub(r'CARAVEL_LITE\?=1', r'CARAVEL_LITE=0', content)
+with open(Full_path_to_caravel_Make, 'w') as file:
+    file.write(content)


### PR DESCRIPTION
added the https://github.com/efabless/caravel_user_project as a submodule for iobsoc.
caravel_user_project is conjunction of scripts that build the open tools and pdks to build a user chip based on verilog/analog. The process of caravel is automatized for digital design.
The avalable PDKS are sky130 node A and node B, and Gfmcu180 node D.