### PR TITLE
added submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "submodules/AXI"]
 	path = submodules/AXI
 	url = git@github.com:IObundle/verilog-axi.git
+[submodule "submodules/caravel_project"]
+	path = submodules/caravel_project
+	url = https://github.com/IObundle/caravel_project


### PR DESCRIPTION
Added caravel_user_project submodule.
Are a conjuction of scripts that install the pdk and the requirement tools for the design of the caravel chip using sky130 or gf180