### PR TITLE
fix(hw): add `_i` and `_o` sufixes to module ports

### DIFF
--- a/hardware/simulation/src/iob_soc_sim_wrapper.v
+++ b/hardware/simulation/src/iob_soc_sim_wrapper.v
@@ -18,13 +18,13 @@ module iob_soc_sim_wrapper (
    output                             trap_o,
 
    // UART for testbench
-   input                              uart_avalid,
-   input [`IOB_UART_SWREG_ADDR_W-1:0] uart_addr,
-   input [`IOB_SOC_DATA_W-1:0]        uart_wdata,
-   input [3:0]                        uart_wstrb,
-   output [`IOB_SOC_DATA_W-1:0]       uart_rdata,
-   output                             uart_ready,
-   output                             uart_rvalid
+   input                              uart_avalid_i,
+   input [`IOB_UART_SWREG_ADDR_W-1:0] uart_addr_i,
+   input [`IOB_SOC_DATA_W-1:0]        uart_wdata_i,
+   input [3:0]                        uart_wstrb_i,
+   output [`IOB_SOC_DATA_W-1:0]       uart_rdata_o,
+   output                             uart_ready_o,
+   output                             uart_rvalid_o
 );
 
    localparam AXI_ID_W = 4;
@@ -94,13 +94,13 @@ module iob_soc_sim_wrapper (
       .cke_i (cke),
       .arst_i(arst_i),
 
-      .iob_avalid_i(uart_avalid),
-      .iob_addr_i  (uart_addr),
-      .iob_wdata_i (uart_wdata),
-      .iob_wstrb_i (uart_wstrb),
-      .iob_rdata_o (uart_rdata),
-      .iob_rvalid_o(uart_rvalid),
-      .iob_ready_o (uart_ready),
+      .iob_avalid_i(uart_avalid_i),
+      .iob_addr_i  (uart_addr_i),
+      .iob_wdata_i (uart_wdata_i),
+      .iob_wstrb_i (uart_wstrb_i),
+      .iob_rdata_o (uart_rdata_o),
+      .iob_rvalid_o(uart_rvalid_o),
+      .iob_ready_o (uart_ready_o),
 
       .txd_o(uart_rxd_i),
       .rxd_i(uart_txd_o),

--- a/hardware/simulation/src/iob_soc_sim_wrapper.v
+++ b/hardware/simulation/src/iob_soc_sim_wrapper.v
@@ -18,7 +18,7 @@ module iob_soc_sim_wrapper (
    output                             trap_o,
 
    // UART for testbench
-   input                              uart_avalid_i,
+   input                              uart_valid_i,
    input [`IOB_UART_SWREG_ADDR_W-1:0] uart_addr_i,
    input [`IOB_SOC_DATA_W-1:0]        uart_wdata_i,
    input [3:0]                        uart_wstrb_i,
@@ -94,7 +94,7 @@ module iob_soc_sim_wrapper (
       .cke_i (cke),
       .arst_i(arst_i),
 
-      .iob_avalid_i(uart_avalid_i),
+      .iob_valid_i(uart_valid_i),
       .iob_addr_i  (uart_addr_i),
       .iob_wdata_i (uart_wdata_i),
       .iob_wstrb_i (uart_wstrb_i),

--- a/hardware/simulation/src/iob_soc_tb.cpp
+++ b/hardware/simulation/src/iob_soc_tb.cpp
@@ -48,23 +48,23 @@ void uartwrite(unsigned int cpu_address, unsigned int cpu_data,
     break;
   }
   dut->uart_addr_i = cpu_address;
-  dut->uart_avalid_i = 1;
+  dut->uart_valid_i = 1;
   dut->uart_wstrb_i = wstrb_int << (cpu_address & 0b011);
   dut->uart_wdata_i = cpu_data
                       << ((cpu_address & 0b011) * 8); // align data to 32 bits
   Timer(CLK_PERIOD);
   dut->uart_wstrb_i = 0;
-  dut->uart_avalid_i = 0;
+  dut->uart_valid_i = 0;
 }
 
 // 2-cycle read
 void uartread(unsigned int cpu_address, char *read_reg) {
   dut->uart_addr_i = cpu_address;
-  dut->uart_avalid_i = 1;
+  dut->uart_valid_i = 1;
   Timer(CLK_PERIOD);
   *read_reg =
       (dut->uart_rdata_o) >> ((cpu_address & 0b011) * 8); // align to 32 bits
-  dut->uart_avalid_i = 0;
+  dut->uart_valid_i = 0;
 }
 
 void inituart() {
@@ -99,7 +99,7 @@ int main(int argc, char **argv, char **env) {
   Timer(100);
   dut->arst_i = 0;
 
-  dut->uart_avalid_i = 0;
+  dut->uart_valid_i = 0;
   dut->uart_wstrb_i = 0;
   inituart();
 

--- a/hardware/simulation/src/iob_soc_tb.cpp
+++ b/hardware/simulation/src/iob_soc_tb.cpp
@@ -47,24 +47,24 @@ void uartwrite(unsigned int cpu_address, unsigned int cpu_data,
     wstrb_int = 0b01111;
     break;
   }
-  dut->uart_addr = cpu_address;
-  dut->uart_avalid = 1;
-  dut->uart_wstrb = wstrb_int << (cpu_address & 0b011);
-  dut->uart_wdata = cpu_data
-                    << ((cpu_address & 0b011) * 8); // align data to 32 bits
+  dut->uart_addr_i = cpu_address;
+  dut->uart_avalid_i = 1;
+  dut->uart_wstrb_i = wstrb_int << (cpu_address & 0b011);
+  dut->uart_wdata_i = cpu_data
+                      << ((cpu_address & 0b011) * 8); // align data to 32 bits
   Timer(CLK_PERIOD);
-  dut->uart_wstrb = 0;
-  dut->uart_avalid = 0;
+  dut->uart_wstrb_i = 0;
+  dut->uart_avalid_i = 0;
 }
 
 // 2-cycle read
 void uartread(unsigned int cpu_address, char *read_reg) {
-  dut->uart_addr = cpu_address;
-  dut->uart_avalid = 1;
+  dut->uart_addr_i = cpu_address;
+  dut->uart_avalid_i = 1;
   Timer(CLK_PERIOD);
   *read_reg =
-      (dut->uart_rdata) >> ((cpu_address & 0b011) * 8); // align to 32 bits
-  dut->uart_avalid = 0;
+      (dut->uart_rdata_o) >> ((cpu_address & 0b011) * 8); // align to 32 bits
+  dut->uart_avalid_i = 0;
 }
 
 void inituart() {
@@ -99,8 +99,8 @@ int main(int argc, char **argv, char **env) {
   Timer(100);
   dut->arst_i = 0;
 
-  dut->uart_avalid = 0;
-  dut->uart_wstrb = 0;
+  dut->uart_avalid_i = 0;
+  dut->uart_wstrb_i = 0;
   inituart();
 
   FILE *soc2cnsl_fd;

--- a/hardware/simulation/src/iob_soc_tb.v
+++ b/hardware/simulation/src/iob_soc_tb.v
@@ -106,13 +106,13 @@ module iob_soc_tb;
       .arst_i (arst),
       .trap_o(trap),
 
-      .uart_avalid(iob_avalid_i),
-      .uart_addr  (iob_addr_i),
-      .uart_wdata (iob_wdata_i),
-      .uart_wstrb (iob_wstrb_i),
-      .uart_rdata (iob_rdata_o),
-      .uart_ready (iob_ready_o),
-      .uart_rvalid(iob_rvalid_o)
+      .uart_avalid_i(iob_avalid_i),
+      .uart_addr_i  (iob_addr_i),
+      .uart_wdata_i (iob_wdata_i),
+      .uart_wstrb_i (iob_wstrb_i),
+      .uart_rdata_o (iob_rdata_o),
+      .uart_ready_o (iob_ready_o),
+      .uart_rvalid_o(iob_rvalid_o)
    );
 
    task cpu_inituart;

--- a/hardware/simulation/src/iob_soc_tb.v
+++ b/hardware/simulation/src/iob_soc_tb.v
@@ -33,7 +33,7 @@ module iob_soc_tb;
 
 
    //IOb-SoC uart
-   reg                iob_avalid_i;
+   reg                iob_valid_i;
    reg [`IOB_UART_SWREG_ADDR_W-1:0] iob_addr_i;
    reg [       `IOB_SOC_DATA_W-1:0] iob_wdata_i;
    reg [                       3:0] iob_wstrb_i;
@@ -50,7 +50,7 @@ module iob_soc_tb;
 
    initial begin
       //init cpu bus signals
-      iob_avalid_i = 0;
+      iob_valid_i = 0;
       iob_wstrb_i  = 0;
 
       //reset system
@@ -106,7 +106,7 @@ module iob_soc_tb;
       .arst_i (arst),
       .trap_o(trap),
 
-      .uart_avalid_i(iob_avalid_i),
+      .uart_valid_i(iob_valid_i),
       .uart_addr_i  (iob_addr_i),
       .uart_wdata_i (iob_wdata_i),
       .uart_wstrb_i (iob_wstrb_i),

--- a/hardware/src/iob_soc.v
+++ b/hardware/src/iob_soc.v
@@ -192,12 +192,12 @@ module iob_soc #(
    wire [1+MEM_ADDR_W+1-2+DATA_W+DATA_W/8-1:0] ext_mem0_d_req;
 
    assign ext_mem0_i_req = {
-      ext_mem_i_req[`AVALID(0)],
+      ext_mem_i_req[`VALID(0)],
       ext_mem_i_req[`ADDRESS(0, MEM_ADDR_W)-2],
       ext_mem_i_req[`WRITE(0)]
    };
    assign ext_mem0_d_req = {
-      ext_mem_d_req[`AVALID(0)],
+      ext_mem_d_req[`VALID(0)],
       ext_mem_d_req[`ADDRESS(0, MEM_ADDR_W+1)-2],
       ext_mem_d_req[`WRITE(0)]
    };

--- a/hardware/src/iob_soc.v
+++ b/hardware/src/iob_soc.v
@@ -175,12 +175,12 @@ module iob_soc #(
       .cpu_reset(cpu_reset),
 
       // instruction bus
-      .i_req (int_mem_i_req),
-      .i_resp(int_mem_i_resp),
+      .i_req_i (int_mem_i_req),
+      .i_resp_o(int_mem_i_resp),
 
       //data bus
-      .d_req (slaves_req[0+:`REQ_W]),
-      .d_resp(slaves_resp[0+:`RESP_W])
+      .d_req_i (slaves_req[0+:`REQ_W]),
+      .d_resp_o(slaves_resp[0+:`RESP_W])
    );
 
 `ifdef IOB_SOC_USE_EXTMEM
@@ -218,12 +218,12 @@ module iob_soc #(
       .AXI_DATA_W (AXI_DATA_W)
    ) ext_mem0 (
       // instruction bus
-      .i_req (ext_mem0_i_req),
-      .i_resp(ext_mem_i_resp),
+      .i_req_i (ext_mem0_i_req),
+      .i_resp_o(ext_mem_i_resp),
 
       //data bus
-      .d_req (ext_mem0_d_req),
-      .d_resp(ext_mem_d_resp),
+      .d_req_i (ext_mem0_d_req),
+      .d_resp_o(ext_mem_d_resp),
 
       //AXI INTERFACE
       //address write

--- a/hardware/src/iob_soc_boot_ctr.v
+++ b/hardware/src/iob_soc_boot_ctr.v
@@ -7,30 +7,30 @@ module iob_soc_boot_ctr #(
    parameter BOOTROM_ADDR_W = 0,
    parameter SRAM_ADDR_W    = 0
 ) (
-   output cpu_rst,
-   output boot,
+   output cpu_rst_o,
+   output boot_o,
 
    //cpu interface
-   input                     cpu_avalid,
-   input      [         1:0] cpu_wdata,
-   input      [DATA_W/8-1:0] cpu_wstrb,
-   output     [  DATA_W-1:0] cpu_rdata,
-   output reg                cpu_rvalid,
-   output reg                cpu_ready,
+   input                     cpu_avalid_i,
+   input      [         1:0] cpu_wdata_i,
+   input      [DATA_W/8-1:0] cpu_wstrb_i,
+   output     [  DATA_W-1:0] cpu_rdata_o,
+   output                    cpu_rvalid_o,
+   output                    cpu_ready_o,
 
 
    //sram master write interface
-   output reg                sram_avalid,
-   output     [  ADDR_W-1:0] sram_addr,
-   output     [  DATA_W-1:0] sram_wdata,
-   output reg [DATA_W/8-1:0] sram_wstrb,
+   output                    sram_avalid_o,
+   output     [  ADDR_W-1:0] sram_addr_o,
+   output     [  DATA_W-1:0] sram_wdata_o,
+   output reg [DATA_W/8-1:0] sram_wstrb_o,
 
    `include "clk_en_rst_s_port.vs"
 );
 
 
    //cpu interface: rdata and ready
-   assign cpu_rdata = {{(DATA_W - 1) {1'b0}}, boot};
+   assign cpu_rdata_o = {{(DATA_W - 1) {1'b0}}, boot_o};
    iob_reg #(
       .DATA_W (1),
       .RST_VAL(0)
@@ -38,13 +38,13 @@ module iob_soc_boot_ctr #(
       .clk_i (clk_i),
       .arst_i(arst_i),
       .cke_i (cke_i),
-      .data_i(cpu_avalid & ~(|cpu_wstrb)),
-      .data_o(cpu_rvalid)
+      .data_i(cpu_avalid_i & ~(|cpu_wstrb_i)),
+      .data_o(cpu_rvalid_o)
    );
-   assign cpu_ready = 1'b1;
+   assign cpu_ready_o = 1'b1;
 
    //boot register: (1) load bootloader to sram and run it: (0) run program
-   wire boot_wr = cpu_avalid & |cpu_wstrb;
+   wire boot_wr = cpu_avalid_i & |cpu_wstrb_i;
    reg                                     boot_nxt;
    iob_reg_re #(
       .DATA_W (1),
@@ -55,7 +55,7 @@ module iob_soc_boot_ctr #(
       .cke_i (cke_i),
       .rst_i (1'b0),
       .en_i  (boot_wr),
-      .data_i(cpu_wdata[0]),
+      .data_i(cpu_wdata_i[0]),
       .data_o(boot_nxt)
    );
    iob_reg_r #(
@@ -67,13 +67,13 @@ module iob_soc_boot_ctr #(
       .cke_i (cke_i),
       .rst_i (1'b0),
       .data_i(boot_nxt),
-      .data_o(boot)
+      .data_o(boot_o)
    );
 
 
    //create CPU reset pulse
    wire cpu_rst_req;
-   assign cpu_rst_req = cpu_avalid & (|cpu_wstrb) & cpu_wdata[1];
+   assign cpu_rst_req = cpu_avalid_i & (|cpu_wstrb_i) & cpu_wdata_i[1];
    wire cpu_rst_pulse;
 
    iob_pulse_gen #(
@@ -88,7 +88,7 @@ module iob_soc_boot_ctr #(
    );
 
    wire loading;
-   assign cpu_rst = loading | cpu_rst_pulse;
+   assign cpu_rst_o = loading | cpu_rst_pulse;
 
    //
    // READ BOOT ROM 
@@ -101,7 +101,7 @@ module iob_soc_boot_ctr #(
       if (arst_i) begin
          rom_r_avalid <= 1'b1;
          rom_r_addr   <= {(BOOTROM_ADDR_W - 2) {1'b0}};
-      end else if (boot && rom_r_addr != (2 ** (BOOTROM_ADDR_W - 2) - 1))
+      end else if (boot_o && rom_r_addr != (2 ** (BOOTROM_ADDR_W - 2) - 1))
          rom_r_addr <= rom_r_addr + 1'b1;
       else begin
          rom_r_avalid <= 1'b0;
@@ -117,22 +117,22 @@ module iob_soc_boot_ctr #(
       if (arst_i) begin
          sram_w_avalid <= 1'b0;
          sram_w_addr   <= -{1'b1, {(BOOTROM_ADDR_W - 2) {1'b0}}};
-         sram_wstrb    <= {DATA_W / 8{1'b1}};
-      end else if (boot) begin
+         sram_wstrb_o    <= {DATA_W / 8{1'b1}};
+      end else if (boot_o) begin
          sram_w_avalid <= rom_r_avalid;
          sram_w_addr   <= -{1'b1, {(BOOTROM_ADDR_W - 2) {1'b0}}} + rom_r_addr;
-         sram_wstrb    <= {DATA_W / 8{rom_r_avalid}};
+         sram_wstrb_o    <= {DATA_W / 8{rom_r_avalid}};
       end else begin
          sram_w_avalid <= 1'b0;
          sram_w_addr   <= -{1'b1, {(BOOTROM_ADDR_W - 2) {1'b0}}};
-         sram_wstrb    <= {DATA_W / 8{1'b1}};
+         sram_wstrb_o    <= {DATA_W / 8{1'b1}};
       end
 
    assign loading     = rom_r_avalid | sram_w_avalid;
 
-   assign sram_avalid = sram_w_avalid;
-   assign sram_addr   = {sram_w_addr, 2'b00};
-   assign sram_wdata  = rom_r_rdata;
+   assign sram_avalid_o = sram_w_avalid;
+   assign sram_addr_o   = {sram_w_addr, 2'b00};
+   assign sram_wdata_o  = rom_r_rdata;
 
    //
    //INSTANTIATE ROM

--- a/hardware/src/iob_soc_ext_mem.v
+++ b/hardware/src/iob_soc_ext_mem.v
@@ -15,12 +15,12 @@ module iob_soc_ext_mem #(
    parameter AXI_DATA_W  = 0
 ) (
    // Instruction bus
-   input  [1+FIRM_ADDR_W-2+`WRITE_W-1:0] i_req,
-   output [                 `RESP_W-1:0] i_resp,
+   input  [1+FIRM_ADDR_W-2+`WRITE_W-1:0] i_req_i,
+   output [                 `RESP_W-1:0] i_resp_o,
 
    // Data bus
-   input  [1+1+MEM_ADDR_W-2+`WRITE_W-1:0] d_req,
-   output [                  `RESP_W-1:0] d_resp,
+   input  [1+1+MEM_ADDR_W-2+`WRITE_W-1:0] d_req_i,
+   output [                  `RESP_W-1:0] d_resp_o,
 
    // AXI interface
    `include "axi_m_port.vs"
@@ -52,13 +52,13 @@ module iob_soc_ext_mem #(
       .arst_i(arst_i),
 
       // Front-end interface
-      .iob_avalid_i        (i_req[1+FIRM_ADDR_W-2+`WRITE_W-1]),
-      .iob_addr_i          (i_req[`ADDRESS(0, FIRM_ADDR_W-2)]),
-      .iob_wdata_i         (i_req[`WDATA(0)]),
-      .iob_wstrb_i         (i_req[`WSTRB(0)]),
-      .iob_rdata_o         (i_resp[`RDATA(0)]),
-      .iob_rvalid_o        (i_resp[`RVALID(0)]),
-      .iob_ready_o         (i_resp[`READY(0)]),
+      .iob_avalid_i        (i_req_i[1+FIRM_ADDR_W-2+`WRITE_W-1]),
+      .iob_addr_i          (i_req_i[`ADDRESS(0, FIRM_ADDR_W-2)]),
+      .iob_wdata_i         (i_req_i[`WDATA(0)]),
+      .iob_wstrb_i         (i_req_i[`WSTRB(0)]),
+      .iob_rdata_o         (i_resp_o[`RDATA(0)]),
+      .iob_rvalid_o        (i_resp_o[`RVALID(0)]),
+      .iob_ready_o         (i_resp_o[`READY(0)]),
       //Control IO
       .invalidate_i (1'b0),
       .invalidate_o(),
@@ -116,13 +116,13 @@ module iob_soc_ext_mem #(
       .arst_i(arst_i),
 
       // Front-end interface
-      .iob_avalid_i        (d_req[2+MEM_ADDR_W-2+`WRITE_W-1]),
-      .iob_addr_i          (d_req[`ADDRESS(0, 1+MEM_ADDR_W-2)]),
-      .iob_wdata_i         (d_req[`WDATA(0)]),
-      .iob_wstrb_i         (d_req[`WSTRB(0)]),
-      .iob_rdata_o         (d_resp[`RDATA(0)]),
-      .iob_rvalid_o        (d_resp[`RVALID(0)]),
-      .iob_ready_o         (d_resp[`READY(0)]),
+      .iob_avalid_i        (d_req_i[2+MEM_ADDR_W-2+`WRITE_W-1]),
+      .iob_addr_i          (d_req_i[`ADDRESS(0, 1+MEM_ADDR_W-2)]),
+      .iob_wdata_i         (d_req_i[`WDATA(0)]),
+      .iob_wstrb_i         (d_req_i[`WSTRB(0)]),
+      .iob_rdata_o         (d_resp_o[`RDATA(0)]),
+      .iob_rvalid_o        (d_resp_o[`RVALID(0)]),
+      .iob_ready_o         (d_resp_o[`READY(0)]),
       //Control IO
       .invalidate_i (1'b0),
       .invalidate_o(invalidate),

--- a/hardware/src/iob_soc_ext_mem.v
+++ b/hardware/src/iob_soc_ext_mem.v
@@ -52,7 +52,7 @@ module iob_soc_ext_mem #(
       .arst_i(arst_i),
 
       // Front-end interface
-      .iob_avalid_i        (i_req_i[1+FIRM_ADDR_W-2+`WRITE_W-1]),
+      .iob_valid_i        (i_req_i[1+FIRM_ADDR_W-2+`WRITE_W-1]),
       .iob_addr_i          (i_req_i[`ADDRESS(0, FIRM_ADDR_W-2)]),
       .iob_wdata_i         (i_req_i[`WDATA(0)]),
       .iob_wstrb_i         (i_req_i[`WSTRB(0)]),
@@ -65,7 +65,7 @@ module iob_soc_ext_mem #(
       .wtb_empty_i  (1'b1),
       .wtb_empty_o (),
       // Back-end interface
-      .be_avalid_o     (icache_be_req[1+MEM_ADDR_W+`WRITE_W-1]),
+      .be_valid_o     (icache_be_req[1+MEM_ADDR_W+`WRITE_W-1]),
       .be_addr_o       (icache_be_req[`ADDRESS(0, MEM_ADDR_W)]),
       .be_wdata_o      (icache_be_req[`WDATA(0)]),
       .be_wstrb_o      (icache_be_req[`WSTRB(0)]),
@@ -82,12 +82,12 @@ module iob_soc_ext_mem #(
    wire l2_wtb_empty;
    wire invalidate;
    reg invalidate_reg;
-   wire l2_avalid = l2cache_req[1+MEM_ADDR_W+`WRITE_W-1];
+   wire l2_valid = l2cache_req[1+MEM_ADDR_W+`WRITE_W-1];
    //Necessary logic to avoid invalidating L2 while it's being accessed by a request
    always @(posedge clk_i, posedge arst_i)
       if (arst_i) invalidate_reg <= 1'b0;
       else if (invalidate) invalidate_reg <= 1'b1;
-      else if (~l2_avalid) invalidate_reg <= 1'b0;
+      else if (~l2_valid) invalidate_reg <= 1'b0;
       else invalidate_reg <= invalidate_reg;
 
    //
@@ -116,7 +116,7 @@ module iob_soc_ext_mem #(
       .arst_i(arst_i),
 
       // Front-end interface
-      .iob_avalid_i        (d_req_i[2+MEM_ADDR_W-2+`WRITE_W-1]),
+      .iob_valid_i        (d_req_i[2+MEM_ADDR_W-2+`WRITE_W-1]),
       .iob_addr_i          (d_req_i[`ADDRESS(0, 1+MEM_ADDR_W-2)]),
       .iob_wdata_i         (d_req_i[`WDATA(0)]),
       .iob_wstrb_i         (d_req_i[`WSTRB(0)]),
@@ -129,7 +129,7 @@ module iob_soc_ext_mem #(
       .wtb_empty_i  (l2_wtb_empty),
       .wtb_empty_o (),
       // Back-end interface
-      .be_avalid_o     (dcache_be_req[1+MEM_ADDR_W+`WRITE_W-1]),
+      .be_valid_o     (dcache_be_req[1+MEM_ADDR_W+`WRITE_W-1]),
       .be_addr_o       (dcache_be_req[`ADDRESS(0, MEM_ADDR_W)]),
       .be_wdata_o      (dcache_be_req[`WDATA(0)]),
       .be_wstrb_o      (dcache_be_req[`WSTRB(0)]),
@@ -184,7 +184,7 @@ module iob_soc_ext_mem #(
       .USE_CTRL_CNT (0)            //Remove counters
    ) l2cache (
       // Native interface
-      .iob_avalid_i        (l2cache_valid),
+      .iob_valid_i        (l2cache_valid),
       .iob_addr_i          (l2cache_addr),
       .iob_wdata_i         (l2cache_wdata),
       .iob_wstrb_i         (l2cache_wstrb),
@@ -192,7 +192,7 @@ module iob_soc_ext_mem #(
       .iob_rvalid_o        (l2cache_rvalid),
       .iob_ready_o         (l2cache_ready),
       //Control IO
-      .invalidate_i (invalidate_reg & ~l2_avalid),
+      .invalidate_i (invalidate_reg & ~l2_valid),
       .invalidate_o(),
       .wtb_empty_i  (1'b1),
       .wtb_empty_o (l2_wtb_empty),

--- a/hardware/src/iob_soc_int_mem.v
+++ b/hardware/src/iob_soc_int_mem.v
@@ -17,12 +17,12 @@ module iob_soc_int_mem #(
    output cpu_reset,
 
    //instruction bus
-   input  [ `REQ_W-1:0] i_req,
-   output [`RESP_W-1:0] i_resp,
+   input  [ `REQ_W-1:0] i_req_i,
+   output [`RESP_W-1:0] i_resp_o,
 
    //data bus
-   input  [ `REQ_W-1:0] d_req,
-   output [`RESP_W-1:0] d_resp,
+   input  [ `REQ_W-1:0] d_req_i,
+   output [`RESP_W-1:0] d_resp_o,
    `include "clk_en_rst_s_port.vs"
 );
 
@@ -53,8 +53,8 @@ module iob_soc_int_mem #(
       .clk_i   (clk_i),
       .arst_i  (arst_i),
       // master interface
-      .m_req_i (d_req),
-      .m_resp_o(d_resp),
+      .m_req_i (d_req_i),
+      .m_resp_o(d_resp_o),
 
       // slaves interface
       .s_req_o ({boot_ctr_req, ram_d_req}),
@@ -77,26 +77,26 @@ module iob_soc_int_mem #(
       .BOOTROM_ADDR_W(BOOTROM_ADDR_W),
       .SRAM_ADDR_W   (SRAM_ADDR_W)
    ) boot_ctr0 (
-      .clk_i  (clk_i),
-      .arst_i (arst_i),
-      .cke_i  (cke_i),
-      .cpu_rst(cpu_reset),
-      .boot   (boot),
+      .clk_i    (clk_i),
+      .arst_i   (arst_i),
+      .cke_i    (cke_i),
+      .cpu_rst_o(cpu_reset),
+      .boot_o   (boot),
 
       //cpu slave interface
       //no address bus since single address
-      .cpu_avalid(boot_ctr_req[`AVALID(0)]),
-      .cpu_wdata (boot_ctr_req[`WDATA(0)-(DATA_W-2)]),
-      .cpu_wstrb (boot_ctr_req[`WSTRB(0)]),
-      .cpu_rdata (boot_ctr_resp[`RDATA(0)]),
-      .cpu_rvalid(boot_ctr_resp[`RVALID(0)]),
-      .cpu_ready (boot_ctr_resp[`READY(0)]),
+      .cpu_avalid_i(boot_ctr_req[`AVALID(0)]),
+      .cpu_wdata_i (boot_ctr_req[`WDATA(0)-(DATA_W-2)]),
+      .cpu_wstrb_i (boot_ctr_req[`WSTRB(0)]),
+      .cpu_rdata_o (boot_ctr_resp[`RDATA(0)]),
+      .cpu_rvalid_o(boot_ctr_resp[`RVALID(0)]),
+      .cpu_ready_o (boot_ctr_resp[`READY(0)]),
 
       //sram write master interface
-      .sram_avalid(ram_w_req[`AVALID(0)]),
-      .sram_addr  (ram_w_req[`ADDRESS(0, ADDR_W)]),
-      .sram_wdata (ram_w_req[`WDATA(0)]),
-      .sram_wstrb (ram_w_req[`WSTRB(0)])
+      .sram_avalid_o(ram_w_req[`AVALID(0)]),
+      .sram_addr_o  (ram_w_req[`ADDRESS(0, ADDR_W)]),
+      .sram_wdata_o (ram_w_req[`WDATA(0)]),
+      .sram_wstrb_o (ram_w_req[`WSTRB(0)])
    );
 
    //
@@ -119,13 +119,13 @@ module iob_soc_int_mem #(
 
    //instruction bus: connect directly but address
    assign ram_r_req[`ADDRESS(0, ADDR_W)] = ram_r_addr;
-   assign boot_i_addr = i_req[`ADDRESS(0, ADDR_W)] + boot_offset;
-   assign i_addr = i_req[`ADDRESS(0, ADDR_W)];
+   assign boot_i_addr = i_req_i[`ADDRESS(0, ADDR_W)] + boot_offset;
+   assign i_addr = i_req_i[`ADDRESS(0, ADDR_W)];
 
-   assign ram_r_req[`AVALID(0)] = i_req[`AVALID(0)];
+   assign ram_r_req[`AVALID(0)] = i_req_i[`AVALID(0)];
    assign ram_r_addr = boot ? boot_i_addr : i_addr;
-   assign ram_r_req[`WRITE(0)] = i_req[`WRITE(0)];
-   assign i_resp[`RESP(0)] = ram_r_resp[`RESP(0)];
+   assign ram_r_req[`WRITE(0)] = i_req_i[`WRITE(0)];
+   assign i_resp_o[`RESP(0)] = ram_r_resp[`RESP(0)];
 
    //data bus: just replace address
    assign boot_ram_d_addr = ram_d_req[`ADDRESS(0, SRAM_ADDR_W)-2] + boot_offset[SRAM_ADDR_W-1:2];
@@ -172,22 +172,22 @@ module iob_soc_int_mem #(
       .arst_i(arst_i),
 
       //instruction bus
-      .i_avalid(ram_i_req[`AVALID(0)]),
-      .i_addr  (ram_i_req[`ADDRESS(0, SRAM_ADDR_W)-2]),
-      .i_wdata (ram_i_req[`WDATA(0)]),
-      .i_wstrb (ram_i_req[`WSTRB(0)]),
-      .i_rdata (ram_i_resp[`RDATA(0)]),
-      .i_rvalid(ram_i_resp[`RVALID(0)]),
-      .i_ready (ram_i_resp[`READY(0)]),
+      .i_avalid_i(ram_i_req[`AVALID(0)]),
+      .i_addr_i  (ram_i_req[`ADDRESS(0, SRAM_ADDR_W)-2]),
+      .i_wdata_i (ram_i_req[`WDATA(0)]),
+      .i_wstrb_i (ram_i_req[`WSTRB(0)]),
+      .i_rdata_o (ram_i_resp[`RDATA(0)]),
+      .i_rvalid_o(ram_i_resp[`RVALID(0)]),
+      .i_ready_o (ram_i_resp[`READY(0)]),
 
       //data bus
-      .d_avalid(ram_d_req[`AVALID(0)]),
-      .d_addr  (ram_d_addr),
-      .d_wdata (ram_d_req[`WDATA(0)]),
-      .d_wstrb (ram_d_req[`WSTRB(0)]),
-      .d_rdata (ram_d_resp[`RDATA(0)]),
-      .d_rvalid(ram_d_resp[`RVALID(0)]),
-      .d_ready (ram_d_resp[`READY(0)])
+      .d_avalid_i(ram_d_req[`AVALID(0)]),
+      .d_addr_i  (ram_d_addr),
+      .d_wdata_i (ram_d_req[`WDATA(0)]),
+      .d_wstrb_i (ram_d_req[`WSTRB(0)]),
+      .d_rdata_o (ram_d_resp[`RDATA(0)]),
+      .d_rvalid_o(ram_d_resp[`RVALID(0)]),
+      .d_ready_o (ram_d_resp[`READY(0)])
    );
 
 endmodule

--- a/hardware/src/iob_soc_int_mem.v
+++ b/hardware/src/iob_soc_int_mem.v
@@ -85,7 +85,7 @@ module iob_soc_int_mem #(
 
       //cpu slave interface
       //no address bus since single address
-      .cpu_avalid_i(boot_ctr_req[`AVALID(0)]),
+      .cpu_valid_i(boot_ctr_req[`VALID(0)]),
       .cpu_wdata_i (boot_ctr_req[`WDATA(0)-(DATA_W-2)]),
       .cpu_wstrb_i (boot_ctr_req[`WSTRB(0)]),
       .cpu_rdata_o (boot_ctr_resp[`RDATA(0)]),
@@ -93,7 +93,7 @@ module iob_soc_int_mem #(
       .cpu_ready_o (boot_ctr_resp[`READY(0)]),
 
       //sram write master interface
-      .sram_avalid_o(ram_w_req[`AVALID(0)]),
+      .sram_valid_o(ram_w_req[`VALID(0)]),
       .sram_addr_o  (ram_w_req[`ADDRESS(0, ADDR_W)]),
       .sram_wdata_o (ram_w_req[`WDATA(0)]),
       .sram_wstrb_o (ram_w_req[`WSTRB(0)])
@@ -122,7 +122,7 @@ module iob_soc_int_mem #(
    assign boot_i_addr = i_req_i[`ADDRESS(0, ADDR_W)] + boot_offset;
    assign i_addr = i_req_i[`ADDRESS(0, ADDR_W)];
 
-   assign ram_r_req[`AVALID(0)] = i_req_i[`AVALID(0)];
+   assign ram_r_req[`VALID(0)] = i_req_i[`VALID(0)];
    assign ram_r_addr = boot ? boot_i_addr : i_addr;
    assign ram_r_req[`WRITE(0)] = i_req_i[`WRITE(0)];
    assign i_resp_o[`RESP(0)] = ram_r_resp[`RESP(0)];
@@ -172,7 +172,7 @@ module iob_soc_int_mem #(
       .arst_i(arst_i),
 
       //instruction bus
-      .i_avalid_i(ram_i_req[`AVALID(0)]),
+      .i_valid_i(ram_i_req[`VALID(0)]),
       .i_addr_i  (ram_i_req[`ADDRESS(0, SRAM_ADDR_W)-2]),
       .i_wdata_i (ram_i_req[`WDATA(0)]),
       .i_wstrb_i (ram_i_req[`WSTRB(0)]),
@@ -181,7 +181,7 @@ module iob_soc_int_mem #(
       .i_ready_o (ram_i_resp[`READY(0)]),
 
       //data bus
-      .d_avalid_i(ram_d_req[`AVALID(0)]),
+      .d_valid_i(ram_d_req[`VALID(0)]),
       .d_addr_i  (ram_d_addr),
       .d_wdata_i (ram_d_req[`WDATA(0)]),
       .d_wstrb_i (ram_d_req[`WSTRB(0)]),

--- a/hardware/src/iob_soc_sram.v
+++ b/hardware/src/iob_soc_sram.v
@@ -8,36 +8,36 @@ module iob_soc_sram #(
    parameter HEXFILE     = "none"
 ) (
    // intruction bus
-   input                        i_avalid,
-   input      [SRAM_ADDR_W-3:0] i_addr,
-   input      [     DATA_W-1:0] i_wdata,   //used for booting
-   input      [   DATA_W/8-1:0] i_wstrb,   //used for booting
-   output     [     DATA_W-1:0] i_rdata,
-   output reg                   i_rvalid,
-   output reg                   i_ready,
+   input                        i_avalid_i,
+   input      [SRAM_ADDR_W-3:0] i_addr_i,
+   input      [     DATA_W-1:0] i_wdata_i,   //used for booting
+   input      [   DATA_W/8-1:0] i_wstrb_i,   //used for booting
+   output     [     DATA_W-1:0] i_rdata_o,
+   output                       i_rvalid_o,
+   output                       i_ready_o,
 
    // data bus
-   input                        d_avalid,
-   input      [SRAM_ADDR_W-3:0] d_addr,
-   input      [     DATA_W-1:0] d_wdata,
-   input      [   DATA_W/8-1:0] d_wstrb,
-   output     [     DATA_W-1:0] d_rdata,
-   output reg                   d_rvalid,
-   output reg                   d_ready,
+   input                        d_avalid_i,
+   input      [SRAM_ADDR_W-3:0] d_addr_i,
+   input      [     DATA_W-1:0] d_wdata_i,
+   input      [   DATA_W/8-1:0] d_wstrb_i,
+   output     [     DATA_W-1:0] d_rdata_o,
+   output                       d_rvalid_o,
+   output                       d_ready_o,
 
    `include "clk_en_rst_s_port.vs"
 );
 
 `ifdef USE_SPRAM
 
-   wire d_avalid_int = i_avalid ? 1'b0 : d_avalid;
-   wire avalid = i_avalid ? i_avalid : d_avalid;
-   wire [SRAM_ADDR_W-3:0] addr = i_avalid ? i_addr : d_addr;
-   wire [DATA_W-1:0] wdata = i_avalid ? i_wdata : d_wdata;
-   wire [DATA_W/8-1:0] wstrb = i_avalid ? i_wstrb : d_wstrb;
+   wire d_avalid_int = i_avalid_i ? 1'b0 : d_avalid_i;
+   wire avalid = i_avalid_i ? i_avalid_i : d_avalid_i;
+   wire [SRAM_ADDR_W-3:0] addr = i_avalid_i ? i_addr_i : d_addr_i;
+   wire [DATA_W-1:0] wdata = i_avalid_i ? i_wdata_i : d_wdata_i;
+   wire [DATA_W/8-1:0] wstrb = i_avalid_i ? i_wstrb_i : d_wstrb_i;
    wire [DATA_W-1:0] rdata;
-   assign d_rdata = rdata;
-   assign i_rdata = rdata;
+   assign d_rdata_o = rdata;
+   assign i_rdata_o = rdata;
 
    iob_ram_sp_be #(
       .HEXFILE(HEXFILE),
@@ -64,18 +64,18 @@ module iob_soc_sram #(
       .clk_i(clk_i),
 
       // data port
-      .enA_i  (d_avalid),
-      .addrA_i(d_addr),
-      .weA_i  (d_wstrb),
-      .dA_i   (d_wdata),
-      .dA_o   (d_rdata),
+      .enA_i  (d_avalid_i),
+      .addrA_i(d_addr_i),
+      .weA_i  (d_wstrb_i),
+      .dA_i   (d_wdata_i),
+      .dA_o   (d_rdata_o),
 
       // instruction port
-      .enB_i  (i_avalid),
-      .addrB_i(i_addr),
-      .weB_i  (i_wstrb),
-      .dB_i   (i_wdata),
-      .dB_o   (i_rdata)
+      .enB_i  (i_avalid_i),
+      .addrB_i(i_addr_i),
+      .weB_i  (i_wstrb_i),
+      .dB_i   (i_wdata_i),
+      .dB_o   (i_rdata_o)
    );
 `else  // !`ifdef MEM_NO_READ_ON_WRITE
    iob_ram_dp_be_xil #(
@@ -86,23 +86,25 @@ module iob_soc_sram #(
       .clk_i(clk_i),
 
       // data port
-      .enA_i  (d_avalid),
-      .addrA_i(d_addr),
-      .weA_i  (d_wstrb),
-      .dA_i   (d_wdata),
-      .dA_o   (d_rdata),
+      .enA_i  (d_avalid_i),
+      .addrA_i(d_addr_i),
+      .weA_i  (d_wstrb_i),
+      .dA_i   (d_wdata_i),
+      .dA_o   (d_rdata_o),
 
       // instruction port
-      .enB_i  (i_avalid),
-      .addrB_i(i_addr),
-      .weB_i  (i_wstrb),
-      .dB_i   (i_wdata),
-      .dB_o   (i_rdata)
+      .enB_i  (i_avalid_i),
+      .addrB_i(i_addr_i),
+      .weB_i  (i_wstrb_i),
+      .dB_i   (i_wdata_i),
+      .dB_o   (i_rdata_o)
    );
 `endif
 `endif
 
    // reply with ready 
+   wire i_rvalid_nxt;
+   assign i_rvalid_nxt = i_avalid_i & ~(|i_wstrb_i);
 
    iob_reg #(
       .DATA_W (1),
@@ -111,9 +113,13 @@ module iob_soc_sram #(
       .clk_i (clk_i),
       .arst_i(arst_i),
       .cke_i (cke_i),
-      .data_i(i_avalid & ~(|i_wstrb)),
-      .data_o(i_rvalid)
+      .data_i(i_rvalid_nxt),
+      .data_o(i_rvalid_o)
    );
+
+   wire d_rvalid_nxt;
+   assign d_rvalid_nxt = d_avalid_i & ~(|d_wstrb_i);
+
    iob_reg #(
       .DATA_W (1),
       .RST_VAL(0)
@@ -121,10 +127,10 @@ module iob_soc_sram #(
       .clk_i (clk_i),
       .arst_i(arst_i),
       .cke_i (cke_i),
-      .data_i(d_avalid & ~(|d_wstrb)),
-      .data_o(d_rvalid)
+      .data_i(d_rvalid_nxt),
+      .data_o(d_rvalid_o)
    );
-   assign i_ready = 1'b1;  // SRAM ready is supposed to always be 1 since requests can be continuous
-   assign d_ready = 1'b1;
+   assign i_ready_o = 1'b1;  // SRAM ready is supposed to always be 1 since requests can be continuous
+   assign d_ready_o = 1'b1;
 
 endmodule

--- a/hardware/src/iob_soc_sram.v
+++ b/hardware/src/iob_soc_sram.v
@@ -8,7 +8,7 @@ module iob_soc_sram #(
    parameter HEXFILE     = "none"
 ) (
    // intruction bus
-   input                        i_avalid_i,
+   input                        i_valid_i,
    input      [SRAM_ADDR_W-3:0] i_addr_i,
    input      [     DATA_W-1:0] i_wdata_i,   //used for booting
    input      [   DATA_W/8-1:0] i_wstrb_i,   //used for booting
@@ -17,7 +17,7 @@ module iob_soc_sram #(
    output                       i_ready_o,
 
    // data bus
-   input                        d_avalid_i,
+   input                        d_valid_i,
    input      [SRAM_ADDR_W-3:0] d_addr_i,
    input      [     DATA_W-1:0] d_wdata_i,
    input      [   DATA_W/8-1:0] d_wstrb_i,
@@ -30,11 +30,11 @@ module iob_soc_sram #(
 
 `ifdef USE_SPRAM
 
-   wire d_avalid_int = i_avalid_i ? 1'b0 : d_avalid_i;
-   wire avalid = i_avalid_i ? i_avalid_i : d_avalid_i;
-   wire [SRAM_ADDR_W-3:0] addr = i_avalid_i ? i_addr_i : d_addr_i;
-   wire [DATA_W-1:0] wdata = i_avalid_i ? i_wdata_i : d_wdata_i;
-   wire [DATA_W/8-1:0] wstrb = i_avalid_i ? i_wstrb_i : d_wstrb_i;
+   wire d_valid_int = i_valid_i ? 1'b0 : d_valid_i;
+   wire valid = i_valid_i ? i_valid_i : d_valid_i;
+   wire [SRAM_ADDR_W-3:0] addr = i_valid_i ? i_addr_i : d_addr_i;
+   wire [DATA_W-1:0] wdata = i_valid_i ? i_wdata_i : d_wdata_i;
+   wire [DATA_W/8-1:0] wstrb = i_valid_i ? i_wstrb_i : d_wstrb_i;
    wire [DATA_W-1:0] rdata;
    assign d_rdata_o = rdata;
    assign i_rdata_o = rdata;
@@ -47,7 +47,7 @@ module iob_soc_sram #(
       .clk_i(clk_i),
 
       // data port
-      .en_i  (avalid),
+      .en_i  (valid),
       .addr_i(addr),
       .we_i  (wstrb),
       .d_i   (wdata),
@@ -64,14 +64,14 @@ module iob_soc_sram #(
       .clk_i(clk_i),
 
       // data port
-      .enA_i  (d_avalid_i),
+      .enA_i  (d_valid_i),
       .addrA_i(d_addr_i),
       .weA_i  (d_wstrb_i),
       .dA_i   (d_wdata_i),
       .dA_o   (d_rdata_o),
 
       // instruction port
-      .enB_i  (i_avalid_i),
+      .enB_i  (i_valid_i),
       .addrB_i(i_addr_i),
       .weB_i  (i_wstrb_i),
       .dB_i   (i_wdata_i),
@@ -86,14 +86,14 @@ module iob_soc_sram #(
       .clk_i(clk_i),
 
       // data port
-      .enA_i  (d_avalid_i),
+      .enA_i  (d_valid_i),
       .addrA_i(d_addr_i),
       .weA_i  (d_wstrb_i),
       .dA_i   (d_wdata_i),
       .dA_o   (d_rdata_o),
 
       // instruction port
-      .enB_i  (i_avalid_i),
+      .enB_i  (i_valid_i),
       .addrB_i(i_addr_i),
       .weB_i  (i_wstrb_i),
       .dB_i   (i_wdata_i),
@@ -104,7 +104,7 @@ module iob_soc_sram #(
 
    // reply with ready 
    wire i_rvalid_nxt;
-   assign i_rvalid_nxt = i_avalid_i & ~(|i_wstrb_i);
+   assign i_rvalid_nxt = i_valid_i & ~(|i_wstrb_i);
 
    iob_reg #(
       .DATA_W (1),
@@ -118,7 +118,7 @@ module iob_soc_sram #(
    );
 
    wire d_rvalid_nxt;
-   assign d_rvalid_nxt = d_avalid_i & ~(|d_wstrb_i);
+   assign d_rvalid_nxt = d_valid_i & ~(|d_wstrb_i);
 
    iob_reg #(
       .DATA_W (1),

--- a/scripts/iob_soc_create_wrapper_files.py
+++ b/scripts/iob_soc_create_wrapper_files.py
@@ -104,8 +104,8 @@ def create_interconnect_instance(out_dir, name, num_extmem_connections):
       .S_COUNT     ({num_extmem_connections}),
       .M_COUNT     (1)
    ) system_axi_interconnect (
-      .clk(clk_i),
-      .rst(arst_i),
+      .clk(clk),
+      .rst(arst),
 
       // Need to use manually defined connections because awlock and arlock of interconnect is only on bit for each slave
       .s_axi_awid    (axi_awid),    //Address write channel ID.

--- a/submodules/LIB/hardware/modules/apb2iob/hardware/src/apb2iob.v
+++ b/submodules/LIB/hardware/modules/apb2iob/hardware/src/apb2iob.v
@@ -32,7 +32,7 @@ module apb2iob #(
    assign apb_ready_nxt = ~apb_ready_o & iob_ready_i & apb_sel_i & apb_enable_i;
    assign apb_rdata_o = iob_rdata_i;
 
-   assign iob_avalid_o = apb_sel_i & apb_enable_i & ~apb_ready_o;
+   assign iob_valid_o = apb_sel_i & apb_enable_i & ~apb_ready_o;
    assign iob_addr_o   = apb_addr_i;
    assign iob_wdata_o  = apb_wdata_i;
    assign iob_wstrb_o  = apb_wstrb_i;

--- a/submodules/LIB/hardware/modules/axi2iob/hardware/src/axi2iob.v
+++ b/submodules/LIB/hardware/modules/axi2iob/hardware/src/axi2iob.v
@@ -59,7 +59,7 @@ module axi2iob #(
     /*
      * IOb-bus master interface
      */
-    output wire                  iob_avalid_o,
+    output wire                  iob_valid_o,
     output wire [ADDR_WIDTH-1:0] iob_addr_o,
     output wire [DATA_WIDTH-1:0] iob_wdata_o,
     output wire [STRB_WIDTH-1:0] iob_wstrb_o,
@@ -123,7 +123,7 @@ module axi2iob #(
   assign m_axil_rvalid = iob_rvalid_i ? 1'b1 : iob_rvalid_q;
 
   // COMPUTE IOb OUTPUTS
-  assign iob_avalid_o = (m_axil_bvalid_n & write_enable) | m_axil_arvalid;
+  assign iob_valid_o = (m_axil_bvalid_n & write_enable) | m_axil_arvalid;
   assign iob_addr_o = m_axil_arvalid ? m_axil_araddr : (m_axil_awvalid ? m_axil_awaddr : m_axil_awaddr_q);
   assign iob_wdata_o = m_axil_wdata;
   assign iob_wstrb_o = m_axil_arvalid ? {STRB_WIDTH{1'b0}} : m_axil_wstrb;

--- a/submodules/LIB/hardware/modules/axi2iob/hardware/src/axi2iob.v
+++ b/submodules/LIB/hardware/modules/axi2iob/hardware/src/axi2iob.v
@@ -20,41 +20,41 @@ module axi2iob #(
     /*
      * AXI slave interface
      */
-    input  wire [AXI_ID_WIDTH-1:0] s_axi_awid,
-    input  wire [  ADDR_WIDTH-1:0] s_axi_awaddr,
-    input  wire [             7:0] s_axi_awlen,
-    input  wire [             2:0] s_axi_awsize,
-    input  wire [             1:0] s_axi_awburst,
-    input  wire                    s_axi_awlock,
-    input  wire [             3:0] s_axi_awcache,
-    input  wire [             2:0] s_axi_awprot,
-    input  wire                    s_axi_awvalid,
-    output wire                    s_axi_awready,
-    input  wire [  DATA_WIDTH-1:0] s_axi_wdata,
-    input  wire [  STRB_WIDTH-1:0] s_axi_wstrb,
-    input  wire                    s_axi_wlast,
-    input  wire                    s_axi_wvalid,
-    output wire                    s_axi_wready,
-    output wire [AXI_ID_WIDTH-1:0] s_axi_bid,
-    output wire [             1:0] s_axi_bresp,
-    output wire                    s_axi_bvalid,
-    input  wire                    s_axi_bready,
-    input  wire [AXI_ID_WIDTH-1:0] s_axi_arid,
-    input  wire [  ADDR_WIDTH-1:0] s_axi_araddr,
-    input  wire [             7:0] s_axi_arlen,
-    input  wire [             2:0] s_axi_arsize,
-    input  wire [             1:0] s_axi_arburst,
-    input  wire                    s_axi_arlock,
-    input  wire [             3:0] s_axi_arcache,
-    input  wire [             2:0] s_axi_arprot,
-    input  wire                    s_axi_arvalid,
-    output wire                    s_axi_arready,
-    output wire [AXI_ID_WIDTH-1:0] s_axi_rid,
-    output wire [  DATA_WIDTH-1:0] s_axi_rdata,
-    output wire [             1:0] s_axi_rresp,
-    output wire                    s_axi_rlast,
-    output wire                    s_axi_rvalid,
-    input  wire                    s_axi_rready,
+    input  wire [AXI_ID_WIDTH-1:0] s_axi_awid_i,
+    input  wire [  ADDR_WIDTH-1:0] s_axi_awaddr_i,
+    input  wire [             7:0] s_axi_awlen_i,
+    input  wire [             2:0] s_axi_awsize_i,
+    input  wire [             1:0] s_axi_awburst_i,
+    input  wire                    s_axi_awlock_i,
+    input  wire [             3:0] s_axi_awcache_i,
+    input  wire [             2:0] s_axi_awprot_i,
+    input  wire                    s_axi_awvalid_i,
+    output wire                    s_axi_awready_o,
+    input  wire [  DATA_WIDTH-1:0] s_axi_wdata_i,
+    input  wire [  STRB_WIDTH-1:0] s_axi_wstrb_i,
+    input  wire                    s_axi_wlast_i,
+    input  wire                    s_axi_wvalid_i,
+    output wire                    s_axi_wready_o,
+    output wire [AXI_ID_WIDTH-1:0] s_axi_bid_o,
+    output wire [             1:0] s_axi_bresp_o,
+    output wire                    s_axi_bvalid_o,
+    input  wire                    s_axi_bready_i,
+    input  wire [AXI_ID_WIDTH-1:0] s_axi_arid_i,
+    input  wire [  ADDR_WIDTH-1:0] s_axi_araddr_i,
+    input  wire [             7:0] s_axi_arlen_i,
+    input  wire [             2:0] s_axi_arsize_i,
+    input  wire [             1:0] s_axi_arburst_i,
+    input  wire                    s_axi_arlock_i,
+    input  wire [             3:0] s_axi_arcache_i,
+    input  wire [             2:0] s_axi_arprot_i,
+    input  wire                    s_axi_arvalid_i,
+    output wire                    s_axi_arready_o,
+    output wire [AXI_ID_WIDTH-1:0] s_axi_rid_o,
+    output wire [  DATA_WIDTH-1:0] s_axi_rdata_o,
+    output wire [             1:0] s_axi_rresp_o,
+    output wire                    s_axi_rlast_o,
+    output wire                    s_axi_rvalid_o,
+    input  wire                    s_axi_rready_i,
 
     /*
      * IOb-bus master interface
@@ -197,11 +197,11 @@ module axi2iob #(
   reg m_axil_wvalid_reg, m_axil_wvalid_next;
   reg m_axil_bready_reg, m_axil_bready_next;
 
-  assign s_axi_awready  = s_axi_awready_reg;
-  assign s_axi_wready   = s_axi_wready_reg;
-  assign s_axi_bid      = s_axi_bid_reg;
-  assign s_axi_bresp    = s_axi_bresp_reg;
-  assign s_axi_bvalid   = s_axi_bvalid_reg;
+  assign s_axi_awready_o  = s_axi_awready_reg;
+  assign s_axi_wready_o   = s_axi_wready_reg;
+  assign s_axi_bid_o      = s_axi_bid_reg;
+  assign s_axi_bresp_o    = s_axi_bresp_reg;
+  assign s_axi_bvalid_o   = s_axi_bvalid_reg;
 
   assign m_axil_awaddr  = m_axil_awaddr_reg;
   assign m_axil_awprot  = m_axil_awprot_reg;
@@ -231,7 +231,7 @@ module axi2iob #(
     s_axi_wready_next        = 1'b0;
     s_axi_bid_next           = s_axi_bid_reg;
     s_axi_bresp_next         = s_axi_bresp_reg;
-    s_axi_bvalid_next        = s_axi_bvalid_reg & ~s_axi_bready;
+    s_axi_bvalid_next        = s_axi_bvalid_reg & ~s_axi_bready_i;
     m_axil_awaddr_next       = m_axil_awaddr_reg;
     m_axil_awprot_next       = m_axil_awprot_reg;
     m_axil_awvalid_next      = m_axil_awvalid_reg & ~m_axil_awready;
@@ -246,15 +246,15 @@ module axi2iob #(
         s_axi_awready_next = ~m_axil_awvalid;
         w_first_transfer_next = 1'b1;
 
-        if (s_axi_awready & s_axi_awvalid) begin
+        if (s_axi_awready_o & s_axi_awvalid_i) begin
           s_axi_awready_next  = 1'b0;
-          w_id_next           = s_axi_awid;
-          m_axil_awaddr_next  = s_axi_awaddr;
-          w_addr_next         = s_axi_awaddr;
-          w_burst_next        = s_axi_awlen;
+          w_id_next           = s_axi_awid_i;
+          m_axil_awaddr_next  = s_axi_awaddr_i;
+          w_addr_next         = s_axi_awaddr_i;
+          w_burst_next        = s_axi_awlen_i;
           w_burst_size_next   = s_axi_awsize;
           w_burst_active_next = 1'b1;
-          m_axil_awprot_next  = s_axi_awprot;
+          m_axil_awprot_next  = s_axi_awprot_i;
           m_axil_awvalid_next = 1'b1;
           s_axi_wready_next   = ~m_axil_wvalid;
           w_state_next        = STATE_DATA;
@@ -266,15 +266,15 @@ module axi2iob #(
         // data state; transfer write data
         s_axi_wready_next = ~m_axil_wvalid;
 
-        if (s_axi_wready & s_axi_wvalid) begin
-          m_axil_wdata_next   = s_axi_wdata;
-          m_axil_wstrb_next   = s_axi_wstrb;
+        if (s_axi_wready_o & s_axi_wvalid_i) begin
+          m_axil_wdata_next   = s_axi_wdata_i;
+          m_axil_wstrb_next   = s_axi_wstrb_i;
           m_axil_wvalid_next  = 1'b1;
           w_burst_next        = w_burst_reg - 1;
           w_burst_active_next = w_burst_reg != 0;
           w_addr_next         = w_addr_reg + (1 << w_burst_size_reg);
           s_axi_wready_next   = 1'b0;
-          m_axil_bready_next  = ~s_axi_bvalid & ~m_axil_awvalid;
+          m_axil_bready_next  = ~s_axi_bvalid_o & ~m_axil_awvalid;
           w_state_next        = STATE_RESP;
         end else begin
           w_state_next = STATE_DATA;
@@ -282,7 +282,7 @@ module axi2iob #(
       end
       STATE_RESP: begin
         // resp state; transfer write response
-        m_axil_bready_next = ~s_axi_bvalid & ~m_axil_awvalid;
+        m_axil_bready_next = ~s_axi_bvalid_o & ~m_axil_awvalid;
 
         if (m_axil_bready & m_axil_bvalid) begin
           m_axil_bready_next    = 1'b0;
@@ -392,12 +392,12 @@ module axi2iob #(
   reg m_axil_arvalid_reg, m_axil_arvalid_next;
   reg m_axil_rready_reg, m_axil_rready_next;
 
-  assign s_axi_arready  = s_axi_arready_reg;
-  assign s_axi_rid      = s_axi_rid_reg;
-  assign s_axi_rdata    = s_axi_rdata_reg;
-  assign s_axi_rresp    = s_axi_rresp_reg;
-  assign s_axi_rlast    = s_axi_rlast_reg;
-  assign s_axi_rvalid   = s_axi_rvalid_reg;
+  assign s_axi_arready_o  = s_axi_arready_reg;
+  assign s_axi_rid_o      = s_axi_rid_reg;
+  assign s_axi_rdata_o    = s_axi_rdata_reg;
+  assign s_axi_rresp_o    = s_axi_rresp_reg;
+  assign s_axi_rlast_o    = s_axi_rlast_reg;
+  assign s_axi_rvalid_o   = s_axi_rvalid_reg;
 
   assign m_axil_araddr  = m_axil_araddr_reg;
   assign m_axil_arprot  = m_axil_arprot_reg;
@@ -421,7 +421,7 @@ module axi2iob #(
     s_axi_rdata_next         = s_axi_rdata_reg;
     s_axi_rresp_next         = s_axi_rresp_reg;
     s_axi_rlast_next         = s_axi_rlast_reg;
-    s_axi_rvalid_next        = s_axi_rvalid_reg & ~s_axi_rready;
+    s_axi_rvalid_next        = s_axi_rvalid_reg & ~s_axi_rready_i;
     m_axil_araddr_next       = m_axil_araddr_reg;
     m_axil_arprot_next       = m_axil_arprot_reg;
     m_axil_arvalid_next      = m_axil_arvalid_reg & ~m_axil_arready;
@@ -432,14 +432,14 @@ module axi2iob #(
         // idle state; wait for new burst
         s_axi_arready_next = ~m_axil_arvalid;
 
-        if (s_axi_arready & s_axi_arvalid) begin
+        if (s_axi_arready_o & s_axi_arvalid_i) begin
           s_axi_arready_next  = 1'b0;
-          r_id_next           = s_axi_arid;
-          m_axil_araddr_next  = s_axi_araddr;
-          r_addr_next         = s_axi_araddr;
-          r_burst_next        = s_axi_arlen;
-          r_burst_size_next   = s_axi_arsize;
-          m_axil_arprot_next  = s_axi_arprot;
+          r_id_next           = s_axi_arid_i;
+          m_axil_araddr_next  = s_axi_araddr_i;
+          r_addr_next         = s_axi_araddr_i;
+          r_burst_next        = s_axi_arlen_i;
+          r_burst_size_next   = s_axi_arsize_i;
+          m_axil_arprot_next  = s_axi_arprot_i;
           m_axil_arvalid_next = 1'b1;
           m_axil_rready_next  = 1'b0;
           r_state_next        = STATE_DATA;
@@ -449,7 +449,7 @@ module axi2iob #(
       end
       STATE_DATA: begin
         // data state; transfer read data
-        m_axil_rready_next = ~s_axi_rvalid & ~m_axil_arvalid;
+        m_axil_rready_next = ~s_axi_rvalid_o & ~m_axil_arvalid;
 
         if (m_axil_rready & m_axil_rvalid) begin
           s_axi_rid_next    = r_id_reg;

--- a/submodules/LIB/hardware/modules/axil2iob/hardware/src/axil2iob.v
+++ b/submodules/LIB/hardware/modules/axil2iob/hardware/src/axil2iob.v
@@ -44,7 +44,7 @@ module axil2iob #(
 
    // COMPUTE IOb OUTPUTS
 
-   assign iob_avalid_o = (axil_wvalid_i & (|axil_wstrb_i)) | axil_arvalid_i;
+   assign iob_valid_o = (axil_wvalid_i & (|axil_wstrb_i)) | axil_arvalid_i;
    assign iob_addr_o = axil_arvalid_i ? axil_araddr_i : axil_awaddr_i;
    assign iob_wdata_o = axil_wdata_i;
    assign iob_wstrb_o = axil_arvalid_i ? {(DATA_W / 8) {1'b0}} : axil_wstrb_i;

--- a/submodules/LIB/hardware/modules/axis2axi/hardware/simulation/src/axis2axi_tb.v
+++ b/submodules/LIB/hardware/modules/axis2axi/hardware/simulation/src/axis2axi_tb.v
@@ -316,15 +316,15 @@ module axis2axi_tb;
       .MAX_DELAY(DELAY_AXI_READ)
    ) delayRead (
       // Connect directly to the same named axi read wires in the master interface
-      .m_rvalid(m_rvalid),
-      .m_rready(m_rready),
+      .m_rvalid_o(m_rvalid),
+      .m_rready_i(m_rready),
 
       // Connect directly to the same named axi read wires in the slave interface
-      .s_rvalid(s_rvalid),
-      .s_rready(s_rready),
+      .s_rvalid_i(s_rvalid),
+      .s_rready_o(s_rready),
 
-      .clk(clk),
-      .rst(rst)
+      .clk_i(clk),
+      .rst_i(rst)
    );
 
    wire m_wvalid, m_wready, s_wvalid, s_wready;
@@ -332,15 +332,15 @@ module axis2axi_tb;
       .MAX_DELAY(DELAY_AXI_WRITE)
    ) delayWrite (
       // Connect directly to the same named axi write wires in the master interface
-      .m_wvalid(m_wvalid),
-      .m_wready(m_wready),
+      .m_wvalid_i(m_wvalid),
+      .m_wready_o(m_wready),
 
       // Connect directly to the same named axi write wires in the slave interface
-      .s_wvalid(s_wvalid),
-      .s_wready(s_wready),
+      .s_wvalid_o(s_wvalid),
+      .s_wready_i(s_wready),
 
-      .clk(clk),
-      .rst(rst)
+      .clk_i(clk),
+      .rst_i(rst)
    );
 
    wire delayed_axis_in_valid, delayed_axis_in_ready;
@@ -348,30 +348,30 @@ module axis2axi_tb;
       .MAX_DELAY(DELAY_AXIS_IN)
    ) delayIn (
       // Master interface. Connect to a slave interface
-      .m_valid(delayed_axis_in_valid),
-      .m_ready(delayed_axis_in_ready),
+      .m_valid_o(delayed_axis_in_valid),
+      .m_ready_i(delayed_axis_in_ready),
 
       // Slave interface. Connect to a master interface
-      .s_valid(axis_in_valid),
-      .s_ready(axis_in_ready),
+      .s_valid_i(axis_in_valid),
+      .s_ready_o(axis_in_ready),
 
-      .clk(clk),
-      .rst(rst)
+      .clk_i(clk),
+      .rst_i(rst)
    );
 
    axidelay #(
       .MAX_DELAY(DELAY_AXIS_OUT)
    ) delayOut (
       // Master interface. Connect to a slave interface
-      .m_valid(delayed_axis_out_valid),
-      .m_ready(delayed_axis_out_ready),
+      .m_valid_o(delayed_axis_out_valid),
+      .m_ready_i(delayed_axis_out_ready),
 
       // Slave interface. Connect to a master interface
-      .s_valid(non_delayed_axis_out_valid),
-      .s_ready(non_delayed_axis_out_ready),
+      .s_valid_i(non_delayed_axis_out_valid),
+      .s_ready_o(non_delayed_axis_out_ready),
 
-      .clk(clk),
-      .rst(rst)
+      .clk_i(clk),
+      .rst_i(rst)
    );
 
    axis2axi #(

--- a/submodules/LIB/hardware/modules/axis2axi/hardware/src/axidelay.v
+++ b/submodules/LIB/hardware/modules/axis2axi/hardware/src/axidelay.v
@@ -7,30 +7,30 @@ module axidelay #(
    parameter MAX_DELAY = 3
 ) (
    // Master interface. Connect to a slave interface
-   output reg m_valid,
-   input      m_ready,
+   output reg m_valid_o,
+   input      m_ready_i,
 
    // Slave interface. Connect to a master interface
-   input      s_valid,
-   output reg s_ready,
+   input      s_valid_i,
+   output reg s_ready_o,
 
-   input clk,
-   input rst
+   input clk_i,
+   input rst_i
 );
 
    generate
       if (MAX_DELAY == 0) begin
          always @* begin
-            s_ready = m_ready;
-            m_valid = s_valid;
+            s_ready_o = m_ready_i;
+            m_valid_o = s_valid_i;
          end
       end else begin
          reg [$clog2(MAX_DELAY):0] counter;
-         always @(posedge clk, posedge rst) begin
-            if (rst) begin
+         always @(posedge clk_i, posedge rst_i) begin
+            if (rst_i) begin
                counter <= 0;
             end else begin
-               if (counter == 0 && m_valid && m_ready) begin
+               if (counter == 0 && m_valid_o && m_ready_i) begin
                   counter <= ($urandom % MAX_DELAY);
                end
 
@@ -39,12 +39,12 @@ module axidelay #(
          end
 
          always @* begin
-            s_ready = 1'b0;
-            m_valid = 1'b0;
+            s_ready_o = 1'b0;
+            m_valid_o = 1'b0;
 
             if (counter == 0) begin
-               s_ready = m_ready;
-               m_valid = s_valid;
+               s_ready_o = m_ready_i;
+               m_valid_o = s_valid_i;
             end
          end
       end
@@ -58,28 +58,28 @@ module axidelayRead #(
    parameter MAX_DELAY = 3
 ) (
    // Connect directly to the same named axi read wires in the master interface
-   output m_rvalid,
-   input  m_rready,
+   output m_rvalid_o,
+   input  m_rready_i,
 
    // Connect directly to the same named axi read wires in the slave interface
-   input  s_rvalid,
-   output s_rready,
+   input  s_rvalid_i,
+   output s_rready_o,
 
-   input clk,
-   input rst
+   input clk_i,
+   input rst_i
 );
 
    axidelay #(
       .MAX_DELAY(MAX_DELAY)
    ) Read (
-      .s_valid(s_rvalid),
-      .s_ready(s_rready),
+      .s_valid_i(s_rvalid_i),
+      .s_ready_o(s_rready_o),
 
-      .m_valid(m_rvalid),
-      .m_ready(m_rready),
+      .m_valid_o(m_rvalid_o),
+      .m_ready_i(m_rready_i),
 
-      .clk(clk),
-      .rst(rst)
+      .clk_i(clk_i),
+      .rst_i(rst_i)
    );
 
 endmodule
@@ -90,28 +90,28 @@ module axidelayWrite #(
    parameter MAX_DELAY = 3
 ) (
    // Connect directly to the same named axi write wires in the master interface
-   input  m_wvalid,
-   output m_wready,
+   input  m_wvalid_i,
+   output m_wready_o,
 
    // Connect directly to the same named axi write wires in the slave interface
-   output s_wvalid,
-   input  s_wready,
+   output s_wvalid_o,
+   input  s_wready_i,
 
-   input clk,
-   input rst
+   input clk_i,
+   input rst_i
 );
 
    axidelay #(
       .MAX_DELAY(MAX_DELAY)
    ) Write (
-      .s_valid(m_wvalid),
-      .s_ready(m_wready),
+      .s_valid_i(m_wvalid_i),
+      .s_ready_o(m_wready_o),
 
-      .m_valid(s_wvalid),
-      .m_ready(s_wready),
+      .m_valid_o(s_wvalid_o),
+      .m_ready_i(s_wready_i),
 
-      .clk(clk),
-      .rst(rst)
+      .clk_i(clk_i),
+      .rst_i(rst_i)
    );
 
 endmodule

--- a/submodules/LIB/hardware/modules/iob2apb/hardware/src/iob2apb.v
+++ b/submodules/LIB/hardware/modules/iob2apb/hardware/src/iob2apb.v
@@ -142,7 +142,7 @@ module iob2apb #(
 
       case (pc)
          0: begin
-            if (!iob_avalid_i)  //wait for iob request
+            if (!iob_valid_i)  //wait for iob request
                pc_nxt = pc;
             else begin  // sample iob signals and initiate apb transaction
                apb_addr_nxt  = iob_addr_i;

--- a/submodules/LIB/hardware/modules/iob2axil/hardware/src/iob2axil.v
+++ b/submodules/LIB/hardware/modules/iob2axil/hardware/src/iob2axil.v
@@ -30,7 +30,7 @@ module iob2axil #(
     input  wire [              1:0] axil_rresp_i,
 
     // IOb slave interface
-    input  wire                iob_avalid_i,
+    input  wire                iob_valid_i,
     input  wire [  ADDR_W-1:0] iob_addr_i,
     input  wire [  DATA_W-1:0] iob_wdata_i,
     input  wire [DATA_W/8-1:0] iob_wstrb_i,
@@ -51,12 +51,12 @@ module iob2axil #(
   //
 
   // write address
-  assign axil_awvalid_o = iob_avalid_i & |iob_wstrb_i;
+  assign axil_awvalid_o = iob_valid_i & |iob_wstrb_i;
   assign axil_awaddr_o  = iob_addr_i;
   assign axil_awprot_o  = 3'd2;
 
   // write
-  assign axil_wvalid_o  = iob_avalid_i & |iob_wstrb_i;
+  assign axil_wvalid_o  = iob_valid_i & |iob_wstrb_i;
   assign axil_wdata_o   = iob_wdata_i;
   assign axil_wstrb_o   = iob_wstrb_i;
 
@@ -64,7 +64,7 @@ module iob2axil #(
   assign axil_bready_o  = 1'b1;
 
   // read address
-  assign axil_arvalid_o = iob_avalid_i & ~|iob_wstrb_i;
+  assign axil_arvalid_o = iob_valid_i & ~|iob_wstrb_i;
   assign axil_araddr_o  = iob_addr_i;
   assign axil_arprot_o  = 3'd2;
 

--- a/submodules/LIB/hardware/modules/iob_interface/iob_if_read.drom
+++ b/submodules/LIB/hardware/modules/iob_interface/iob_if_read.drom
@@ -1,6 +1,6 @@
 {signal: [
   {name: 'clk_i', wave: 'p...........'},
-  {name: 'avalid_i', wave: '0..1......0.'},
+  {name: 'valid_i', wave: '0..1......0.'},
   {name: 'ready_o', wave: '0....1..01..'},
 
   {name: 'addr', wave: 'x..=..===.xx', data: ['A0', 'A1', 'A2', 'A3']},

--- a/submodules/LIB/hardware/modules/iob_iob2wishbone/hardware/src/iob_iob2wishbone.v
+++ b/submodules/LIB/hardware/modules/iob_iob2wishbone/hardware/src/iob_iob2wishbone.v
@@ -8,7 +8,7 @@ module iob_iob2wishbone #(
    `include "clk_en_rst_s_port.vs"
 
    // IOb interface
-   input  wire                iob_avalid_i,
+   input  wire                iob_valid_i,
    input  wire [  ADDR_W-1:0] iob_addr_i,
    input  wire [  DATA_W-1:0] iob_wdata_i,
    input  wire [DATA_W/8-1:0] iob_wstrb_i,
@@ -30,7 +30,7 @@ module iob_iob2wishbone #(
    localparam RB_MASK = {1'b0, {READ_BYTES{1'b1}}};
 
    // IOb auxiliar wires
-   wire                iob_avalid_r;
+   wire                iob_valid_r;
    wire [  ADDR_W-1:0] iob_address_r;
    wire [  DATA_W-1:0] iob_wdata_r;
    // Wishbone auxiliar wire
@@ -42,11 +42,11 @@ module iob_iob2wishbone #(
    wire                wb_ack_r;
 
    // Logic
-   assign wb_addr_o   = iob_avalid_i ? iob_addr_i : iob_address_r;
-   assign wb_data_o   = iob_avalid_i ? iob_wdata_i : iob_wdata_r;
-   assign wb_select_o = iob_avalid_i ? wb_select : wb_select_r;
-   assign wb_we_o     = iob_avalid_i ? wb_we : wb_we_r;
-   assign wb_cyc_o    = iob_avalid_i ? iob_avalid_i : iob_avalid_r;
+   assign wb_addr_o   = iob_valid_i ? iob_addr_i : iob_address_r;
+   assign wb_data_o   = iob_valid_i ? iob_wdata_i : iob_wdata_r;
+   assign wb_select_o = iob_valid_i ? wb_select : wb_select_r;
+   assign wb_we_o     = iob_valid_i ? wb_we : wb_we_r;
+   assign wb_cyc_o    = iob_valid_i ? iob_valid_i : iob_valid_r;
    assign wb_stb_o    = wb_cyc_o;
 
    assign wb_select   = wb_we ? iob_wstrb_i : (RB_MASK) << (iob_addr_i[1:0]);
@@ -54,17 +54,17 @@ module iob_iob2wishbone #(
 
    assign iob_rvalid_o = wb_ack_r & (~wb_we_r);
    assign iob_rdata_o  = wb_ack_i ? wb_data_i : wb_data_r;
-   assign iob_ready_o  = (~iob_avalid_r) | wb_ack_r;
+   assign iob_ready_o  = (~iob_valid_r) | wb_ack_r;
 
    iob_reg_re #(
       .DATA_W (1),
       .RST_VAL(0)
-   ) iob_reg_avalid (
+   ) iob_reg_valid (
       `include "clk_en_rst_s_s_portmap.vs"
       .rst_i (wb_ack_i),
-      .en_i  (iob_avalid_i),
-      .data_i(iob_avalid_i),
-      .data_o(iob_avalid_r)
+      .en_i  (iob_valid_i),
+      .data_i(iob_valid_i),
+      .data_o(iob_valid_r)
    );
    iob_reg_re #(
       .DATA_W (ADDR_W),
@@ -72,7 +72,7 @@ module iob_iob2wishbone #(
    ) iob_reg_addr (
       `include "clk_en_rst_s_s_portmap.vs"
       .rst_i (1'b0),
-      .en_i  (iob_avalid_i),
+      .en_i  (iob_valid_i),
       .data_i(iob_addr_i),
       .data_o(iob_address_r)
    );
@@ -82,7 +82,7 @@ module iob_iob2wishbone #(
    ) iob_reg_iob_data (
       `include "clk_en_rst_s_s_portmap.vs"
       .rst_i (1'b0),
-      .en_i  (iob_avalid_i),
+      .en_i  (iob_valid_i),
       .data_i(iob_wdata_i),
       .data_o(iob_wdata_r)
    );
@@ -92,7 +92,7 @@ module iob_iob2wishbone #(
    ) iob_reg_we (
       `include "clk_en_rst_s_s_portmap.vs"
       .rst_i (1'b0),
-      .en_i  (iob_avalid_i),
+      .en_i  (iob_valid_i),
       .data_i(wb_we),
       .data_o(wb_we_r)
    );
@@ -102,7 +102,7 @@ module iob_iob2wishbone #(
    ) iob_reg_strb (
       `include "clk_en_rst_s_s_portmap.vs"
       .rst_i (1'b0),
-      .en_i  (iob_avalid_i),
+      .en_i  (iob_valid_i),
       .data_i(wb_select),
       .data_o(wb_select_r)
    );

--- a/submodules/LIB/hardware/modules/iob_iobuf/hardware/src/iob_iobuf.v
+++ b/submodules/LIB/hardware/modules/iob_iobuf/hardware/src/iob_iobuf.v
@@ -8,10 +8,10 @@
 `timescale 1ns / 1ps
 
 module iob_iobuf (
-   input  i,    // from core
+   input  i_i,    // from core
    input  t_i,  // from core: tristate control
    input  n_i,  // from core: inversion control
-   output o,    // to core
+   output o_o,    // to core
    inout  io    // to device IO
 );
 
@@ -19,18 +19,18 @@ module iob_iobuf (
 
 `ifdef XILINX
    IOBUF IOBUF_inst (
-      .I (i),
+      .I (i_i),
       .T (t_i),
       .O (o_int),
       .IO(io)
    );
 `else
    reg o_var;
-   assign io = t_i ? 1'bz : i;
+   assign io = t_i ? 1'bz : i_i;
    always @* o_var = #1 io;
    assign o_int = o_var;
 `endif
 
-   assign o = (n_i ^ o_int);
+   assign o_o = (n_i ^ o_int);
 
 endmodule

--- a/submodules/LIB/hardware/modules/iob_merge/hardware/src/iob_merge.v
+++ b/submodules/LIB/hardware/modules/iob_merge/hardware/src/iob_merge.v
@@ -22,7 +22,7 @@ module iob_merge #(
   localparam Nb = $clog2(N_MASTERS) + ($clog2(N_MASTERS) == 0);
 
   wire                 s_ready;
-  wire [N_MASTERS-1:0] m_avalid;
+  wire [N_MASTERS-1:0] m_valid;
   reg  [       Nb-1:0] sel;
   wire [       Nb-1:0] sel_q;
 
@@ -31,8 +31,8 @@ module iob_merge #(
   //select master
   generate
     genvar c;
-    for (c = 0; c < N_MASTERS; c = c + 1) begin : g_m_avalids
-      assign m_avalid[c] = m_req_i[`AVALID(c)];
+    for (c = 0; c < N_MASTERS; c = c + 1) begin : g_m_valids
+      assign m_valid[c] = m_req_i[`VALID(c)];
     end
   endgenerate
 
@@ -41,10 +41,10 @@ module iob_merge #(
   //
   integer k;
   always @* begin
-    if (|m_avalid) begin
+    if (|m_valid) begin
       sel = {Nb{1'b0}};
       for (k = 0; k < N_MASTERS; k = k + 1) begin
-        if (m_avalid[k]) sel = k[Nb-1:0];
+        if (m_valid[k]) sel = k[Nb-1:0];
       end
     end else begin
       sel = sel_q;
@@ -79,7 +79,7 @@ module iob_merge #(
     genvar a;
     for (a = 0; a < N_MASTERS; a = a + 1) begin : g_m_ready
       always @* begin
-        if ((sel == a) | (~m_avalid[a])) begin
+        if ((sel == a) | (~m_valid[a])) begin
           m_resp_o[`READY(a)] = s_resp_i[`READY(0)];
         end else begin
           m_resp_o[`READY(a)] = 1'b0;

--- a/submodules/LIB/hardware/modules/iob_merge_v2/hardware/src/iob_merge2.v
+++ b/submodules/LIB/hardware/modules/iob_merge_v2/hardware/src/iob_merge2.v
@@ -17,14 +17,14 @@ module iob_merge #(
    wire [NBITS-1:0] sel, sel_reg;
    assign sel = addr_i[ADDR_W-2-:NBITS];
 
-   //avalid mux
+   //valid mux
    iob_mux #(
       .DATA_W(1),
       .N     (N)
-   ) iob_mux_avalid (
+   ) iob_mux_valid (
       .sel_i (sel),
-      .data_i(avalid_i),
-      .data_o(avalid_o)
+      .data_i(valid_i),
+      .data_o(valid_o)
    );
 
    //addr mux

--- a/submodules/LIB/hardware/modules/iob_split/hardware/src/iob_split.v
+++ b/submodules/LIB/hardware/modules/iob_split/hardware/src/iob_split.v
@@ -24,10 +24,10 @@ module iob_split #(
    //slave select word
    wire [Nb-1:0] s_sel;
    wire [Nb-1:0] s_sel_r;
-   wire m_avalid;
+   wire m_valid;
 
    assign s_sel = m_req_i[P_SLAVES-:Nb];
-   assign m_avalid = m_req_i[`AVALID(0)];
+   assign m_valid = m_req_i[`VALID(0)];
 
    //route master request to selected slave
    integer i;
@@ -58,7 +58,7 @@ module iob_split #(
       `include "clk_rst_s_s_portmap.vs"
       .cke_i (1'b1),
       .rst_i (1'b0),
-      .en_i  (m_avalid),
+      .en_i  (m_valid),
       .data_i(s_sel),
       .data_o(s_sel_r)
    );

--- a/submodules/LIB/hardware/modules/iob_split_v2/hardware/src/iob_split2.v
+++ b/submodules/LIB/hardware/modules/iob_split_v2/hardware/src/iob_split2.v
@@ -16,14 +16,14 @@ module iob_split #(
    wire [NBITS-1:0] sel, sel_reg;
    assign sel = addr_i[ADDR_W-2-:NBITS];
 
-   //avalid demux
+   //valid demux
    iob_demux #(
       .DATA_W(1),
       .N     (N)
-   ) iob_demux_avalid (
+   ) iob_demux_valid (
       .sel_i (sel),
-      .data_i(avalid_i),
-      .data_o(avalid_o)
+      .data_i(valid_i),
+      .data_o(valid_o)
    );
 
    //addr demux

--- a/submodules/LIB/hardware/modules/iob_tasks.vs
+++ b/submodules/LIB/hardware/modules/iob_tasks.vs
@@ -9,14 +9,14 @@ task iob_write;
    input [$clog2(DATA_W):0] width;
 
    begin
-      @(posedge clk) #1 iob_avalid_i = 1;  //sync and assign
+      @(posedge clk) #1 iob_valid_i = 1;  //sync and assign
       iob_addr_i  = `IOB_WORD_ADDR(addr);
       iob_wdata_i = `IOB_GET_WDATA(addr, data);
       iob_wstrb_i = `IOB_GET_WSTRB(addr, width);
 
       while (!iob_ready_o) #1;
 
-      @(posedge clk) iob_avalid_i = 0;
+      @(posedge clk) iob_valid_i = 0;
       iob_wstrb_i = 0;
    end
 endtask
@@ -28,11 +28,11 @@ task iob_read;
    input [$clog2(DATA_W):0] width;
 
    begin
-      @(posedge clk) #1 iob_avalid_i = 1;
+      @(posedge clk) #1 iob_valid_i = 1;
       iob_addr_i = `IOB_WORD_ADDR(addr);
 
       while (!iob_ready_o) #1;
-      @(posedge clk) #1 iob_avalid_i = 0;
+      @(posedge clk) #1 iob_valid_i = 0;
 
       while (!iob_rvalid_o) #1;
       data = #1 `IOB_GET_RDATA(addr, iob_rdata_o, width);

--- a/submodules/LIB/hardware/modules/iob_utils.vh
+++ b/submodules/LIB/hardware/modules/iob_utils.vh
@@ -49,7 +49,7 @@
 //REQ bus
 `define WDATA_P_(D) `WSTRB_W_(D)
 `define ADDR_P_(D) (`WDATA_P_(D)+D)
-`define AVALID_P_(A, D) (`ADDR_P_(D)+A)
+`define VALID_P_(A, D) (`ADDR_P_(D)+A)
 //RESP bus
 `define RDATA_P `VALID_W+`READY_W
 
@@ -71,7 +71,7 @@
 `define RESP_(I, D) (I*`RESP_W_(D)) +: `RESP_W_(D)
 
 //gets the WRITE valid bit of cat bus section
-`define AVALID_(I, A, D) (I*`REQ_W_(A,D)) + `AVALID_P_(A,D)
+`define VALID_(I, A, D) (I*`REQ_W_(A,D)) + `VALID_P_(A,D)
 
 //gets the ADDRESS of cat bus section
 `define ADDRESS_(I, W, A, D) I*`REQ_W_(A,D)+`ADDR_P_(D)+W-1 -: W
@@ -105,14 +105,14 @@
 
 `define WDATA_P `WDATA_P_(DATA_W)
 `define ADDR_P `ADDR_P_(DATA_W)
-`define AVALID_P `AVALID_P_(ADDR_W, DATA_W)
+`define VALID_P `VALID_P_(ADDR_W, DATA_W)
 
 `define REQ_W `REQ_W_(ADDR_W, DATA_W)
 `define RESP_W `RESP_W_(DATA_W)
 
 `define REQ(I) `REQ_(I, ADDR_W, DATA_W)
 `define RESP(I) `RESP_(I, DATA_W)
-`define AVALID(I) `AVALID_(I, ADDR_W, DATA_W)
+`define VALID(I) `VALID_(I, ADDR_W, DATA_W)
 `define ADDRESS(I, W) `ADDRESS_(I, W, ADDR_W, DATA_W)
 `define WDATA(I) `WDATA_(I, ADDR_W, DATA_W)
 `define WSTRB(I) `WSTRB_(I, ADDR_W, DATA_W)

--- a/submodules/LIB/hardware/modules/iob_wishbone2iob/hardware/src/iob_wishbone2iob.v
+++ b/submodules/LIB/hardware/modules/iob_wishbone2iob/hardware/src/iob_wishbone2iob.v
@@ -16,7 +16,7 @@ module iob_wishbone2iob #(
    output wire [  DATA_W-1:0] wb_data_o,
 
    // IOb interface
-   output wire                iob_avalid_o,
+   output wire                iob_valid_o,
    output wire [  ADDR_W-1:0] iob_address_o,
    output wire [  DATA_W-1:0] iob_wdata_o,
    output wire [DATA_W/8-1:0] iob_wstrb_o,
@@ -26,9 +26,9 @@ module iob_wishbone2iob #(
 );
 
    // IOb auxiliar wires
-   wire                avalid;
-   wire                avalid_r;
-   wire                rst_avalid;
+   wire                valid;
+   wire                valid_r;
+   wire                rst_valid;
    wire [DATA_W/8-1:0] wstrb;
    wire [  DATA_W-1:0] rdata_r;
    wire                wack;
@@ -39,18 +39,18 @@ module iob_wishbone2iob #(
    wire [  DATA_W-1:0] wb_data_mask;
 
    // Logic
-   assign iob_avalid_o  = avalid;
+   assign iob_valid_o  = valid;
    assign iob_address_o = wb_addr_i;
    assign iob_wdata_o   = wb_data_i;
    assign iob_wstrb_o   = wstrb;
 
-   assign avalid        = (wb_stb_i & wb_cyc_i) & (~avalid_r);
-   assign rst_avalid    = (~wb_stb_i) & avalid_r;
+   assign valid        = (wb_stb_i & wb_cyc_i) & (~valid_r);
+   assign rst_valid    = (~wb_stb_i) & valid_r;
    assign wstrb         = wb_we_i ? wb_select_i : 4'h0;
 
    assign wb_data_o = (iob_rdata_i) & (wb_data_mask);
    assign wb_ack_o = iob_rvalid_i | wack_r;
-   assign wack = iob_ready_i & iob_avalid_o & (| iob_wstrb_o);
+   assign wack = iob_ready_i & iob_valid_o & (| iob_wstrb_o);
 
    assign wb_data_mask = {
       {8{wb_select_i[3]}}, {8{wb_select_i[2]}}, {8{wb_select_i[1]}}, {8{wb_select_i[0]}}
@@ -59,12 +59,12 @@ module iob_wishbone2iob #(
    iob_reg_re #(
       .DATA_W (1),
       .RST_VAL(0)
-   ) iob_reg_avalid (
+   ) iob_reg_valid (
       `include "clk_en_rst_s_s_portmap.vs"
-      .rst_i (rst_avalid),
-      .en_i  (avalid),
-      .data_i(avalid),
-      .data_o(avalid_r)
+      .rst_i (rst_valid),
+      .en_i  (valid),
+      .data_i(valid),
+      .data_o(valid_r)
    );
    iob_reg_re #(
       .DATA_W (1),

--- a/submodules/LIB/scripts/if_gen.py
+++ b/submodules/LIB/scripts/if_gen.py
@@ -248,7 +248,7 @@ iob = [
         "slave": 1,
         "signal": "output",
         "width": "1",
-        "name": "iob_avalid",
+        "name": "iob_valid",
         "default": "0",
         "description": "Request valid.",
     },

--- a/submodules/LIB/scripts/mkregs.py
+++ b/submodules/LIB/scripts/mkregs.py
@@ -142,7 +142,7 @@ class mkregs:
                 rst_val_str = str(n_bits) + "'d" + str(rst_val)
             f.write(f"wire {name}_wen;\n")
             f.write(
-                f"assign {name}_wen = (iob_avalid_i) & ((|iob_wstrb_i) & {name}_addressed);\n"
+                f"assign {name}_wen = (iob_valid_i) & ((|iob_wstrb_i) & {name}_addressed);\n"
             )
             f.write(f"iob_reg_e #(\n")
             f.write(f"  .DATA_W({n_bits}),\n")
@@ -157,7 +157,7 @@ class mkregs:
             f.write(");\n")
         else:  # compute wen
             f.write(
-                f"assign {name}_wen_o = ({name}_addressed & iob_avalid_i)? |iob_wstrb_i: 1'b0;\n"
+                f"assign {name}_wen_o = ({name}_addressed & iob_valid_i)? |iob_wstrb_i: 1'b0;\n"
             )
             f.write(f"assign {name}_wdata_o = {name}_wdata;\n")
 
@@ -184,7 +184,7 @@ class mkregs:
                     f"assign {name}_addressed = (iob_addr_i >= {addr}) && (iob_addr_i < ({addr}+(2**({addr_w}))));\n"
                 )
             f.write(
-                f"assign {name}_ren_o = {name}_addressed & iob_avalid_i & (~|iob_wstrb_i);\n"
+                f"assign {name}_ren_o = {name}_addressed & iob_valid_i & (~|iob_wstrb_i);\n"
             )
 
     # generate ports for swreg module
@@ -496,7 +496,7 @@ class mkregs:
 
         # rvalid computation
         f_gen.write(
-            "assign rvalid_nxt = (iob_avalid_i & iob_ready_o) & (~(|iob_wstrb_i));\n\n"
+            "assign rvalid_nxt = (iob_valid_i & iob_ready_o) & (~(|iob_wstrb_i));\n\n"
         )
 
         f_gen.write("endmodule\n")

--- a/submodules/LIB/scripts/submodule_utils.py
+++ b/submodules/LIB/scripts/submodule_utils.py
@@ -19,7 +19,7 @@ reserved_signals = {
     "cke_i": ".cke_i(cke_i)",
     "en_i": ".en_i(en_i)",
     "arst_i": ".arst_i(arst_i)",
-    "iob_avalid_i": ".iob_avalid_i(slaves_req[`AVALID(`/*<InstanceName>*/)])",
+    "iob_valid_i": ".iob_valid_i(slaves_req[`VALID(`/*<InstanceName>*/)])",
     "iob_addr_i": ".iob_addr_i(slaves_req[`ADDRESS(`/*<InstanceName>*/,`/*<SwregFilename>*/_ADDR_W)])",
     "iob_wdata_i": ".iob_wdata_i(slaves_req[`WDATA(`/*<InstanceName>*/)])",
     "iob_wstrb_i": ".iob_wstrb_i(slaves_req[`WSTRB(`/*<InstanceName>*/)])",

--- a/submodules/UART/hardware/src/iob_uart.v
+++ b/submodules/UART/hardware/src/iob_uart.v
@@ -10,7 +10,7 @@ module iob_uart #(
 
    `include "iob_wire.vs"
 
-   assign iob_avalid = iob_avalid_i;
+   assign iob_valid = iob_valid_i;
    assign iob_addr = iob_addr_i;
    assign iob_wdata = iob_wdata_i;
    assign iob_wstrb = iob_wstrb_i;


### PR DESCRIPTION
- update CACHE submodule with test fixes
- update SOC and LIB hardware modules with missing `_i` and `_o` sufixes for input and output ports, respectively