### PR TITLE
fix(soc_interconnect): custom clk arst signals

### DIFF
--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_fpga_wrapper.v
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_fpga_wrapper.v
@@ -233,6 +233,12 @@ module iob_soc_fpga_wrapper (
    );
 `endif
 
+    // interconnect clk and arst
+    wire clk_interconnect;
+    wire arst_interconnect;
+    assign clk_interconnect = clk;
+    assign arst_interconnect = arst;
+
    `include "iob_soc_interconnect.vs"
 
 endmodule

--- a/hardware/simulation/src/iob_soc_sim_wrapper.v
+++ b/hardware/simulation/src/iob_soc_sim_wrapper.v
@@ -64,6 +64,13 @@ module iob_soc_sim_wrapper (
       .trap_o(trap_o)
    );
 
+
+    // interconnect clk and arst
+    wire clk_interconnect;
+    wire arst_interconnect;
+    assign clk_interconnect = clk_i;
+    assign arst_interconnect = arst_i;
+
    `include "iob_soc_interconnect.vs"
 
 `ifdef IOB_SOC_USE_EXTMEM

--- a/iob_soc.py
+++ b/iob_soc.py
@@ -379,4 +379,3 @@ class iob_soc(iob_module):
         # Initialize empty lists for attributes (We can't initialize in the attribute declaration because it would cause every subclass to reference the same list)
         cls.peripherals = []
         cls.peripheral_portmap = []
-

--- a/scripts/iob_soc_create_wrapper_files.py
+++ b/scripts/iob_soc_create_wrapper_files.py
@@ -104,8 +104,8 @@ def create_interconnect_instance(out_dir, name, num_extmem_connections):
       .S_COUNT     ({num_extmem_connections}),
       .M_COUNT     (1)
    ) system_axi_interconnect (
-      .clk(clk_i),
-      .rst(arst_i),
+      .clk(clk_interconnect),
+      .rst(arst_interconnect),
 
       // Need to use manually defined connections because awlock and arlock of interconnect is only on bit for each slave
       .s_axi_awid    (axi_awid),    //Address write channel ID.


### PR DESCRIPTION
- update iob_soc_interconnect instance to use `clk_interconnect` and `arst_interconnect` 
  - this allows to connect to clk and arst signals for CycloneV fpga and simulation wrappers 
  - CycloneV has clk and arst - simulation has clk_i and arst_i
  - fixes CycloneV with external memory