### PR TITLE
fix(fpga): cyclonev fpga wrapper, reset_sync

### DIFF
--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_fpga_wrapper.v
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_fpga_wrapper.v
@@ -233,11 +233,13 @@ module iob_soc_fpga_wrapper (
    );
 `endif
 
+`ifdef IOB_SOC_USE_EXTMEM
     // interconnect clk and arst
     wire clk_interconnect;
     wire arst_interconnect;
     assign clk_interconnect = clk;
     assign arst_interconnect = arst;
+`endif
 
    `include "iob_soc_interconnect.vs"
 

--- a/submodules/LIB/hardware/modules/sync/iob_reset_sync/hardware/src/iob_reset_sync.v
+++ b/submodules/LIB/hardware/modules/sync/iob_reset_sync/hardware/src/iob_reset_sync.v
@@ -8,29 +8,38 @@ module iob_reset_sync (
 );
 
    wire [1:0] data;
-   reg [1:0] sync;
+   wire [1:0] sync;
 
    localparam RST_POL = `IOB_REG_RST_POL;
 
    generate
       if (RST_POL == 0) begin: gen_rst_pol_0
          assign data = {sync[0], 1'b1};
+         iob_r #(
+               .DATA_W  (2),
+               .RST_VAL (2'd0)
+               )     
+         reg1 (
+               .clk_i (clk_i),
+               .arst_i (arst_i),
+               .data_i(data),
+               .data_o(sync)
+               );
       end else begin: gen_rst_pol_1
          assign data = {sync[0], 1'b0};
+         iob_r #(
+               .DATA_W  (2),
+               .RST_VAL (2'd3)
+               )     
+         reg1 (
+               .clk_i (clk_i),
+               .arst_i (arst_i),
+               .data_i(data),
+               .data_o(sync)
+               );
       end
    endgenerate
    
-   iob_r #(
-           .DATA_W  (2),
-           .RST_VAL (2'b0)
-           )     
-   reg1 (
-         .clk_i (clk_i),
-         .arst_i (arst_i),
-         .data_i(data),
-         .data_o(sync)
-         );
-
    assign arst_o = sync[1];
    
 endmodule

--- a/submodules/LIB/hardware/modules/sync/iob_reset_sync/hardware/src/iob_reset_sync.v
+++ b/submodules/LIB/hardware/modules/sync/iob_reset_sync/hardware/src/iob_reset_sync.v
@@ -11,34 +11,26 @@ module iob_reset_sync (
    wire [1:0] sync;
 
    localparam RST_POL = `IOB_REG_RST_POL;
+   localparam RST_VAL = `IOB_REG_RST_POL ? 2'd3 : 2'd0;
 
    generate
       if (RST_POL == 0) begin: gen_rst_pol_0
          assign data = {sync[0], 1'b1};
-         iob_r #(
-               .DATA_W  (2),
-               .RST_VAL (2'd0)
-               )     
-         reg1 (
-               .clk_i (clk_i),
-               .arst_i (arst_i),
-               .data_i(data),
-               .data_o(sync)
-               );
       end else begin: gen_rst_pol_1
          assign data = {sync[0], 1'b0};
-         iob_r #(
-               .DATA_W  (2),
-               .RST_VAL (2'd3)
-               )     
-         reg1 (
-               .clk_i (clk_i),
-               .arst_i (arst_i),
-               .data_i(data),
-               .data_o(sync)
-               );
       end
    endgenerate
+
+   iob_r #(
+       .DATA_W  (2),
+       .RST_VAL (RST_VAL)
+       )     
+   reg1 (
+       .clk_i (clk_i),
+       .arst_i (arst_i),
+       .data_i(data),
+       .data_o(sync)
+       );
    
    assign arst_o = sync[1];
    


### PR DESCRIPTION
- only declare clk_interconnect and arst_interconnect signals if Cyclonev is using external memory
- fix reset sync module: 
  - declare sync as `wire` instead of `reg` 
  - instantiate `iob_r` with correct `RST_VAL` in each `RST_POL` case