### PR TITLE
fix(hw): distinct signals for sync regs

### DIFF
--- a/hardware/fpga/vivado/iob_soc_fpga_wrapper_tool.sdc
+++ b/hardware/fpga/vivado/iob_soc_fpga_wrapper_tool.sdc
@@ -1,3 +1,3 @@
-set_property ASYNC_REG TRUE [get_cells -hier {*synchronizer*[*]}]
-set_property ASYNC_REG TRUE [get_cells -hier {*signal_o*[*]}]
+set_property ASYNC_REG TRUE [get_cells -hier {*iob_r_data_o*[*]}]
+set_property ASYNC_REG TRUE [get_cells -hier {*iob_rn_data_o*[*]}]
 set_clock_groups -asynchronous -group {c0_sys_clk_clk_p} -group {enet_clk}

--- a/submodules/LIB/hardware/modules/reg/iob_r/hardware/src/iob_r.v
+++ b/submodules/LIB/hardware/modules/reg/iob_r/hardware/src/iob_r.v
@@ -6,8 +6,8 @@ module iob_r #(
 ) (
 `include "clk_rst_s_port.vs"
 
-   input      [DATA_W-1:0] data_i,
-   output reg [DATA_W-1:0] data_o
+   input      [DATA_W-1:0] iob_r_data_i,
+   output reg [DATA_W-1:0] iob_r_data_o
 );
 
    localparam RST_POL = `IOB_REG_RST_POL;
@@ -16,17 +16,17 @@ module iob_r #(
       if (RST_POL == 1) begin: g_rst_pol_1
          always @(posedge clk_i, posedge arst_i) begin
             if (arst_i) begin
-               data_o <= RST_VAL;
+               iob_r_data_o <= RST_VAL;
             end else begin
-               data_o <= data_i;
+               iob_r_data_o <= iob_r_data_i;
             end
          end
       end else begin: g_rst_pol_0
          always @(posedge clk_i, negedge arst_i) begin
             if (~arst_i) begin
-               data_o <= RST_VAL;
+               iob_r_data_o <= RST_VAL;
             end else begin
-               data_o <= data_i;
+               iob_r_data_o <= iob_r_data_i;
             end
          end
       end

--- a/submodules/LIB/hardware/modules/reg/iob_rn/hardware/src/iob_rn.v
+++ b/submodules/LIB/hardware/modules/reg/iob_rn/hardware/src/iob_rn.v
@@ -6,8 +6,8 @@ module iob_rn #(
 ) (
 `include "clk_rst_s_port.vs"
 
-   input      [DATA_W-1:0] data_i,
-   output reg [DATA_W-1:0] data_o
+   input      [DATA_W-1:0] iob_rn_data_i,
+   output reg [DATA_W-1:0] iob_rn_data_o
 );
 
    localparam RST_POL = `IOB_REG_RST_POL;
@@ -16,17 +16,17 @@ module iob_rn #(
       if (RST_POL == 1) begin: g_rst_pol_1
          always @(negedge clk_i, posedge arst_i) begin
             if (arst_i) begin
-               data_o <= RST_VAL;
+               iob_rn_data_o <= RST_VAL;
             end else begin
-               data_o <= data_i;
+               iob_rn_data_o <= iob_rn_data_i;
             end
          end
       end else begin: g_rst_pol_0
          always @(negedge clk_i, negedge arst_i) begin
             if (~arst_i) begin
-               data_o <= RST_VAL;
+               iob_rn_data_o <= RST_VAL;
             end else begin
-               data_o <= data_i;
+               iob_rn_data_o <= iob_rn_data_i;
             end
          end
       end

--- a/submodules/LIB/hardware/modules/sync/iob_neg2posedge_sync/hardware/src/iob_neg2posedge_sync.v
+++ b/submodules/LIB/hardware/modules/sync/iob_neg2posedge_sync/hardware/src/iob_neg2posedge_sync.v
@@ -10,7 +10,7 @@ module iob_neg2posedge_sync #(
    output reg [DATA_W-1:0] signal_o
 );
    
-   reg [DATA_W-1:0] synchronizer;
+   wire [DATA_W-1:0] synchronizer;
  
    iob_rn #(
            .DATA_W  (DATA_W),
@@ -19,8 +19,8 @@ module iob_neg2posedge_sync #(
    reg1 (
          .clk_i(clk_i),
          .arst_i(arst_i),
-         .data_i(signal_i),
-         .data_o(synchronizer)
+         .iob_rn_data_i(signal_i),
+         .iob_rn_data_o(synchronizer)
          );
    
    iob_r #(
@@ -30,8 +30,8 @@ module iob_neg2posedge_sync #(
    reg2 (
          .clk_i(clk_i),
          .arst_i(arst_i),
-         .data_i(synchronizer),
-         .data_o(signal_o)
+         .iob_r_data_i(synchronizer),
+         .iob_r_data_o(signal_o)
          );
    
 endmodule

--- a/submodules/LIB/hardware/modules/sync/iob_reset_sync/hardware/src/iob_reset_sync.v
+++ b/submodules/LIB/hardware/modules/sync/iob_reset_sync/hardware/src/iob_reset_sync.v
@@ -28,8 +28,8 @@ module iob_reset_sync (
    reg1 (
        .clk_i (clk_i),
        .arst_i (arst_i),
-       .data_i(data),
-       .data_o(sync)
+       .iob_r_data_i(data),
+       .iob_r_data_o(sync)
        );
    
    assign arst_o = sync[1];

--- a/submodules/LIB/hardware/modules/sync/iob_sync/hardware/src/iob_sync.v
+++ b/submodules/LIB/hardware/modules/sync/iob_sync/hardware/src/iob_sync.v
@@ -10,7 +10,7 @@ module iob_sync #(
    output reg [DATA_W-1:0] signal_o
 );
 
-   reg [DATA_W-1:0]        synchronizer;
+   wire [DATA_W-1:0]        synchronizer;
    
    iob_r #(
            .DATA_W  (DATA_W),
@@ -19,8 +19,8 @@ module iob_sync #(
    reg1 (
          .clk_i   (clk_i),
          .arst_i   (arst_i),
-         .data_i(signal_i),
-         .data_o(synchronizer)
+         .iob_r_data_i(signal_i),
+         .iob_r_data_o(synchronizer)
          );
    
    iob_r #(
@@ -30,8 +30,8 @@ module iob_sync #(
    reg2 (
          .clk_i   (clk_i),
          .arst_i   (arst_i),
-         .data_i(synchronizer),
-         .data_o(signal_o)
+         .iob_r_data_i(synchronizer),
+         .iob_r_data_o(signal_o)
          );
    
 endmodule


### PR DESCRIPTION
- use distinct signal names for synchronizer registers. this enables using wildcard rules to identify synchronizer registers in fpga tools
- fix reg to wire
- update PICORV to avoid combinatorial loop