### PR TITLE
Fix module setup order; Only setup flows for top module.

### DIFF
--- a/submodules/LIB/scripts/console_ethernet.py
+++ b/submodules/LIB/scripts/console_ethernet.py
@@ -155,7 +155,7 @@ def main():
         elif byte == DC1:
             print(f"{PROGNAME}: disabling IOB-SOC exclusive identifiers")
             endFileTransfer()
-            script_arguments = ["python3", "../../scripts/noncanonical.py"]
+            script_arguments = ["python3", "../../scripts/terminalMode.py"]
             subprocess.run(script_arguments)
             print(f"{PROGNAME}: start reading user input")
             input_thread.start()

--- a/submodules/LIB/scripts/iob_module.py
+++ b/submodules/LIB/scripts/iob_module.py
@@ -261,14 +261,15 @@ class iob_module:
     @classmethod
     def _post_setup(cls):
         """Launch post(-specific)-setup tasks"""
-        # Setup flows (copy LIB files)
-        build_srcs.flows_setup(cls)
+        # Auto-add common module macros and submodules
+        cls._auto_add_settings()
+
+        if cls.is_top_module:
+            # Setup flows (copy LIB files)
+            build_srcs.flows_setup(cls)
 
         # Copy sources from the module's setup dir (and from its superclasses)
         cls._copy_srcs()
-
-        # Auto-add common module macros and submodules
-        cls._auto_add_settings()
 
         # Generate hw, sw and doc files
         cls._generate_files()

--- a/submodules/UART/hardware/src/uart_core.v
+++ b/submodules/UART/hardware/src/uart_core.v
@@ -1,5 +1,6 @@
 `timescale 1ns / 1ps
 `include "iob_uart_swreg_def.vh"
+`include "iob_reg_conf.vh"
 
 module uart_core (
    input                            clk_i,


### PR DESCRIPTION
Call `_auto_add_settings()` before `_copy_srcs()` in iob_module, to prevent auto added modules (like `iob_ctls`) from overriding top module files.