### PR TITLE
Reorder variable definitions of `fpga_build.mk` 

### DIFF
--- a/hardware/fpga/fpga_build.mk
+++ b/hardware/fpga/fpga_build.mk
@@ -3,10 +3,9 @@ RUN_DEPS+=iob_soc_boot.hex iob_soc_firmware.hex
 # Don't add firmware to BUILD_DEPS if we are not initializing memory since we don't want to rebuild the bitstream when we modify it.
 BUILD_DEPS+=iob_soc_boot.hex $(if $(filter $(INIT_MEM),1),iob_soc_firmware.hex)
 
-
-ROOT_DIR :=../..
-include $(ROOT_DIR)/software/sw_build.mk
-
 IS_FPGA=1
 
 QUARTUS_SEED ?=5
+
+ROOT_DIR :=../..
+include $(ROOT_DIR)/software/sw_build.mk


### PR DESCRIPTION
By setting `IS_FPGA` before including `sw_build.mk`, we can use this variable in the `ifeq` statements of the `sw_build.mk` file.
Currently useful in iob-soc-opencryptolinux.