### PR TITLE
feat(timer): add iob_timer as LIB module

### DIFF
--- a/iob_soc.py
+++ b/iob_soc.py
@@ -13,6 +13,7 @@ from verilog_tools import inplace_change
 from iob_picorv32 import iob_picorv32
 from iob_cache import iob_cache
 from iob_uart import iob_uart
+from iob_timer import iob_timer
 from iob_utils import iob_utils
 from iob_merge import iob_merge
 from iob_split import iob_split
@@ -83,6 +84,8 @@ class iob_soc(iob_module):
             cls.ext_mem = iob_merge("iob_merge_1")
         if iob_uart in cls.submodule_list:
             cls.peripherals.append(iob_uart("UART0"))
+        if iob_timer in cls.submodule_list:
+            cls.peripherals.append(iob_timer("TIMER0"))
 
     @classmethod
     def _create_submodules_list(cls, extra_submodules=[]):
@@ -92,6 +95,7 @@ class iob_soc(iob_module):
                 iob_picorv32,
                 iob_cache,
                 iob_uart,
+                iob_timer,
                 # Hardware headers & modules
                 {"interface": "iob_wire"},
                 {"interface": "axi_wire"},

--- a/software/src/iob_soc_firmware.c
+++ b/software/src/iob_soc_firmware.c
@@ -1,4 +1,5 @@
 #include "bsp.h"
+#include "iob-timer.h"
 #include "iob-uart.h"
 #include "iob_soc_conf.h"
 #include "iob_soc_periphs.h"
@@ -17,6 +18,9 @@ char *send_string = "Sending this string as a file to console.\n"
 int main() {
   char pass_string[] = "Test passed!";
   char fail_string[] = "Test failed!";
+
+  // init timer
+  timer_init(TIMER0_BASE);
 
   // init uart
   uart_init(UART0_BASE, FREQ / BAUD);
@@ -50,6 +54,13 @@ int main() {
   free(recvfile);
 
   uart_sendfile("test.log", strlen(pass_string), pass_string);
+
+  // read current timer count, compute elapsed time
+  unsigned long long elapsed = timer_get_count();
+  unsigned int elapsedu = elapsed / (FREQ / 1000000);
+
+  printf("\nExecution time: %d clock cycles\n", (unsigned int)elapsed);
+  printf("\nExecution time: %dus @%dMHz\n\n", elapsedu, FREQ / 1000000);
 
   uart_finish();
 }

--- a/submodules/LIB/hardware/modules/iob_timer/hardware/simulation/src/timer_tb.v
+++ b/submodules/LIB/hardware/modules/iob_timer/hardware/simulation/src/timer_tb.v
@@ -1,0 +1,71 @@
+`timescale 1ns / 1ps
+`include "iob_utils.vh"
+`include "iob_timer_swreg_def.vh"
+
+module timer_tb;
+
+   localparam PER = 10;
+   localparam DATA_W = 32;
+
+   integer fd;
+
+   reg clk;
+   `IOB_CLOCK(clk, PER)
+
+   reg rst;
+
+   reg TIMER_ENABLE;
+   reg TIMER_SAMPLE;
+   wire [2*DATA_W-1:0] TIMER_VALUE;
+
+   initial begin
+`ifdef VCD
+      $dumpfile("timer.vcd");
+      $dumpvars();
+`endif
+      TIMER_ENABLE = 0;
+      TIMER_SAMPLE = 0;
+
+      rst          = 1;
+      // deassert hard reset
+      @(posedge clk) #1 rst = 0;
+      @(posedge clk) #1 TIMER_ENABLE = 1;
+      @(posedge clk) #1 TIMER_SAMPLE = 1;
+      @(posedge clk) #1 TIMER_SAMPLE = 0;
+
+      //uncomment to fail the test 
+      //@(posedge clk) #1;
+
+      $write("Current time: %d; Timer value %d\n", $time(), TIMER_VALUE);
+      #(1000 * PER) @(posedge clk) #1 TIMER_SAMPLE = 1;
+      @(posedge clk) #1 TIMER_SAMPLE = 0;
+      $write("Current time: %d; Timer value %d\n", $time(), TIMER_VALUE);
+
+      if (TIMER_VALUE == 1003) begin
+         $display("Test passed");
+         fd = $fopen("test.log", "w");
+         $fdisplay(fd, "Test passed!");
+         $fclose(fd);
+
+      end else begin
+         $display("Test failed: expecting timer value 1003 but got %d", TIMER_VALUE);
+         fd = $fopen("test.log", "w");
+         $fdisplay(fd, "Test failed: expecting timer value 1003 but got %d", TIMER_VALUE);
+         $fclose(fd);
+      end
+
+      $finish();
+   end
+
+   //instantiate timer core
+   timer_core timer0 (
+      .en_i(TIMER_ENABLE),
+      .rstrb_i(TIMER_SAMPLE),
+      .time_o(TIMER_VALUE),
+      .clk_i       (clk),
+      .cke_i       (1'b1),
+      .arst_i      (rst),
+      .rst_i       (rst)
+   );
+
+endmodule

--- a/submodules/LIB/hardware/modules/iob_timer/hardware/src/iob_timer.v
+++ b/submodules/LIB/hardware/modules/iob_timer/hardware/src/iob_timer.v
@@ -1,0 +1,46 @@
+`timescale 1ns / 1ps
+`include "iob_timer_conf.vh"
+`include "iob_timer_swreg_def.vh"
+
+module iob_timer #(
+   `include "iob_timer_params.vs"
+) (
+   `include "iob_timer_io.vs"
+);
+
+   `include "iob_wire.vs"
+
+   assign iob_valid = iob_valid_i;
+   assign iob_addr = iob_addr_i;
+   assign iob_wdata = iob_wdata_i;
+   assign iob_wstrb = iob_wstrb_i;
+   assign iob_rvalid_o = iob_rvalid;
+   assign iob_rdata_o = iob_rdata;
+   assign iob_ready_o = iob_ready;
+
+   //Dummy iob_ready_nxt_o and iob_rvalid_nxt_o to be used in swreg (unused ports)
+   wire iob_ready_nxt;
+   wire iob_rvalid_nxt;
+
+   //BLOCK Register File & Configuration, control and status registers accessible by the sofware
+   `include "iob_timer_swreg_inst.vs"
+
+   //
+   //BLOCK 64-bit time counter & Free-running 64-bit counter with enable and soft reset capabilities
+   //
+   wire [2*DATA_W-1:0] time_now;
+
+   timer_core timer0 (
+      .clk_i       (clk_i),
+      .cke_i       (cke_i),
+      .arst_i      (arst_i),
+      .en_i        (ENABLE_wr),
+      .rst_i       (RESET_wr),
+      .rstrb_i     (SAMPLE_wr),
+      .time_o      (time_now)
+   );
+
+   assign DATA_LOW_rd  = time_now[DATA_W-1:0];
+   assign DATA_HIGH_rd = time_now[2*DATA_W-1:DATA_W];
+
+endmodule

--- a/submodules/LIB/hardware/modules/iob_timer/hardware/src/timer_core.v
+++ b/submodules/LIB/hardware/modules/iob_timer/hardware/src/timer_core.v
@@ -1,0 +1,44 @@
+`timescale 1ns / 1ps
+`include "iob_timer_swreg_def.vh"
+
+module timer_core #(
+   parameter DATA_W = 32
+) (
+   input                                                     clk_i,
+   input                                                     cke_i,
+   input                                                     arst_i,
+   input                                                     en_i,
+   input                                                     rst_i,
+   input                                                     rstrb_i,
+   output [`IOB_TIMER_DATA_LOW_W+`IOB_TIMER_DATA_HIGH_W-1:0] time_o
+);
+
+   wire [2*DATA_W-1:0] time_counter;
+
+   iob_counter #(
+      .DATA_W (2 * DATA_W),
+      .RST_VAL(0)
+   ) time_counter_cnt (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .rst_i (rst_i),
+      .en_i  (en_i),
+      .data_o(time_counter)
+   );
+
+   //time counter register
+   iob_reg_re #(
+      .DATA_W (2 * DATA_W),
+      .RST_VAL(0)
+   ) time_counter_reg (
+      .clk_i (clk_i),
+      .cke_i (cke_i),
+      .arst_i(arst_i),
+      .rst_i (rst_i),
+      .en_i  (rstrb_i),
+      .data_i(time_counter),
+      .data_o(time_o)
+   );
+
+endmodule

--- a/submodules/LIB/hardware/modules/iob_timer/iob_timer.py
+++ b/submodules/LIB/hardware/modules/iob_timer/iob_timer.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+import os
+
+from iob_module import iob_module
+
+# Submodules
+from iob_utils import iob_utils
+from iob_reg_re import iob_reg_re
+from iob_reg_e import iob_reg_e
+from iob_counter import iob_counter
+
+
+class iob_timer(iob_module):
+    name = "iob_timer"
+    version = "V0.10"
+    flows = "sim emb"
+    setup_dir = os.path.dirname(__file__)
+
+    @classmethod
+    def _create_submodules_list(cls):
+        """Create submodules list with dependencies of this module"""
+        super()._create_submodules_list(
+            [
+                # Hardware headers & modules
+                {"interface": "iob_s_port"},
+                {"interface": "iob_s_portmap"},
+                {"interface": "iob_wire"},
+                {"interface": "clk_en_rst_s_s_portmap"},
+                {"interface": "clk_en_rst_s_port"},
+                iob_utils,
+                iob_reg_re,
+                iob_reg_e,
+                iob_counter,
+            ]
+        )
+
+    @classmethod
+    def _setup_confs(cls):
+        super()._setup_confs(
+            [
+                # Macros
+                # Parameters
+                {
+                    "name": "DATA_W",
+                    "type": "P",
+                    "val": "32",
+                    "min": "NA",
+                    "max": "NA",
+                    "descr": "Data bus width",
+                },
+                {
+                    "name": "ADDR_W",
+                    "type": "P",
+                    "val": "`IOB_TIMER_SWREG_ADDR_W",
+                    "min": "NA",
+                    "max": "NA",
+                    "descr": "Address bus width",
+                },
+                {
+                    "name": "WDATA_W",
+                    "type": "P",
+                    "val": "1",
+                    "min": "NA",
+                    "max": "8",
+                    "descr": "",
+                },
+            ]
+        )
+
+    @classmethod
+    def _setup_ios(cls):
+        cls.ios += [
+            {"name": "iob_s_port", "descr": "CPU native interface", "ports": []},
+            {
+                "name": "general",
+                "descr": "General interface signals",
+                "ports": [
+                    {
+                        "name": "clk_i",
+                        "type": "I",
+                        "n_bits": "1",
+                        "descr": "System clock input",
+                    },
+                    {
+                        "name": "arst_i",
+                        "type": "I",
+                        "n_bits": "1",
+                        "descr": "System reset, asynchronous and active high",
+                    },
+                    {
+                        "name": "cke_i",
+                        "type": "I",
+                        "n_bits": "1",
+                        "descr": "System reset, asynchronous and active high",
+                    },
+                ],
+            },
+        ]
+
+    @classmethod
+    def _setup_regs(cls):
+        cls.regs += [
+            {
+                "name": "timer",
+                "descr": "TIMER software accessible registers.",
+                "regs": [
+                    {
+                        "name": "RESET",
+                        "type": "W",
+                        "n_bits": 1,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": True,
+                        "descr": "Timer soft reset",
+                    },
+                    {
+                        "name": "ENABLE",
+                        "type": "W",
+                        "n_bits": 1,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": True,
+                        "descr": "Timer enable",
+                    },
+                    {
+                        "name": "SAMPLE",
+                        "type": "W",
+                        "n_bits": 1,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": True,
+                        "descr": "Sample time counter value into a readable register",
+                    },
+                    {
+                        "name": "DATA_LOW",
+                        "type": "R",
+                        "n_bits": 32,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": True,
+                        "descr": "High part of the timer value, which has twice the width of the data word width",
+                    },
+                    {
+                        "name": "DATA_HIGH",
+                        "type": "R",
+                        "n_bits": 32,
+                        "rst_val": 0,
+                        "log2n_items": 0,
+                        "autoreg": True,
+                        "descr": "Low part of the timer value, which has twice the width of the data word width",
+                    },
+                ],
+            }
+        ]
+
+    @classmethod
+    def _setup_block_groups(cls):
+        cls.block_groups += []

--- a/submodules/LIB/hardware/modules/iob_timer/software/example_firmware.c
+++ b/submodules/LIB/hardware/modules/iob_timer/software/example_firmware.c
@@ -1,0 +1,26 @@
+#include "bsp.h"
+#include "iob-timer.h"
+#include "iob-uart.h"
+#include "periphs.h"
+#include "printf.h"
+#include "system.h"
+
+int main() {
+  unsigned long long elapsed;
+  unsigned int elapsedu;
+
+  // init timer and uart
+  timer_init(TIMER0_BASE);
+  uart_init(UART_BASE, FREQ / BAUD);
+
+  printf("\nHello world!\n");
+
+  // read current timer count, compute elapsed time
+  elapsed = timer_get_count();
+  elapsedu = elapsed / (FREQ / 1000000);
+
+  printf("\nExecution time: %d clock cycles\n", (unsigned int)elapsed);
+  printf("\nExecution time: %dus @%dMHz\n\n", elapsedu, FREQ / 1000000);
+
+  uart_finish();
+}

--- a/submodules/LIB/hardware/modules/iob_timer/software/src/iob-timer.c
+++ b/submodules/LIB/hardware/modules/iob_timer/software/src/iob-timer.c
@@ -1,0 +1,28 @@
+#include "iob-timer.h"
+
+// Base Address
+static uint32_t base;
+
+void timer_reset() {
+  IOB_TIMER_SET_RESET(1);
+  IOB_TIMER_SET_RESET(0);
+}
+
+void timer_init(uint32_t base_address) {
+  base = base_address;
+  IOB_TIMER_INIT_BASEADDR(base_address);
+  timer_reset();
+  IOB_TIMER_SET_ENABLE(1);
+}
+
+uint64_t timer_get_count() {
+  // sample timer counter
+  IOB_TIMER_SET_SAMPLE(1);
+  IOB_TIMER_SET_SAMPLE(0);
+
+  uint64_t count = (uint64_t)IOB_TIMER_GET_DATA_HIGH();
+  count <<= IOB_TIMER_DATA_LOW_W;
+  count |= (uint64_t)IOB_TIMER_GET_DATA_LOW();
+
+  return count;
+}

--- a/submodules/LIB/hardware/modules/iob_timer/software/src/iob-timer.h
+++ b/submodules/LIB/hardware/modules/iob_timer/software/src/iob-timer.h
@@ -1,0 +1,7 @@
+#pragma once
+#include "iob_timer_swreg.h"
+
+// Functions
+void timer_reset();
+void timer_init(uint32_t base_address);
+uint64_t timer_get_count();

--- a/submodules/LIB/hardware/modules/iob_timer/software/src/iob_timer_swreg_pc_emul.c
+++ b/submodules/LIB/hardware/modules/iob_timer/software/src/iob_timer_swreg_pc_emul.c
@@ -1,0 +1,72 @@
+/* PC Emulation of TIMER peripheral */
+
+#include <stdint.h>
+#include <time.h>
+
+#include "bsp.h"
+#include "iob_timer_swreg.h"
+
+/* convert clock values from PC CLOCK FREQ to EMBEDDED FREQ */
+#define PC_TO_FREQ_FACTOR ((1.0 * FREQ) / CLOCKS_PER_SEC)
+
+static clock_t start, end, time_counter, counter_reg;
+static int timer_enable;
+
+static int base;
+void IOB_TIMER_INIT_BASEADDR(uint32_t addr) {
+  base = addr;
+  return;
+}
+
+void IOB_TIMER_SET_RESET(uint8_t value) {
+  // use only reg width
+  int rst_int = (value & 0x01);
+  if (rst_int) {
+    start = end = 0;
+    time_counter = 0;
+    timer_enable = 0;
+  }
+  return;
+}
+
+void IOB_TIMER_SET_ENABLE(uint8_t value) {
+  // use only reg width
+  int en_int = (value & 0x01);
+  // manage transitions
+  // 0 -> 1
+  if (timer_enable == 0 && en_int == 1) {
+    // start counting time
+    start = clock();
+  } else if (timer_enable == 1 && en_int == 0) {
+    // accumulate enable interval
+    end = clock();
+    timer_enable += (end - start);
+    start = end = 0; // reset aux clock values
+  }
+  // store enable en_int
+  timer_enable = en_int;
+  return;
+}
+
+void IOB_TIMER_SET_SAMPLE(uint8_t value) {
+  // use only reg width
+  int sample_int = (value & 0x01);
+  if (sample_int) {
+    counter_reg = time_counter;
+    if (start != 0)
+      counter_reg += (clock() - start);
+  }
+  return;
+}
+
+uint32_t IOB_TIMER_GET_DATA_HIGH() {
+  /* convert clock from PC CLOCKS_PER_CYCLE to FREQ */
+  double counter_freq = (1.0 * counter_reg) * PC_TO_FREQ_FACTOR;
+  return ((int)(((unsigned long long)counter_freq) >> 32));
+}
+
+uint32_t IOB_TIMER_GET_DATA_LOW() {
+  /* convert clock from PC CLOCKS_PER_CYCLE to FREQ */
+  double counter_freq = (1.0 * counter_reg) * PC_TO_FREQ_FACTOR;
+  return ((int)(((unsigned long long)counter_freq) & 0xFFFFFFFF));
+}


### PR DESCRIPTION
- add iob_timer to LIB modules - usage example in `iob_timer/software/example_firmware.c`
- add timer to iob-soc system by default
- print execution time in firmware
- addresses https://github.com/IObundle/iob-soc/issues/706