### PR TITLE
feat(is_system): Add `is_system` attribute to `iob_module`

### DIFF
--- a/hardware/fpga/fpga_build.mk
+++ b/hardware/fpga/fpga_build.mk
@@ -3,8 +3,6 @@ RUN_DEPS+=iob_soc_boot.hex iob_soc_firmware.hex
 # Don't add firmware to BUILD_DEPS if we are not initializing memory since we don't want to rebuild the bitstream when we modify it.
 BUILD_DEPS+=iob_soc_boot.hex $(if $(filter $(INIT_MEM),1),iob_soc_firmware.hex)
 
-IS_FPGA=1
-
 QUARTUS_SEED ?=5
 
 ROOT_DIR :=../..

--- a/iob_soc.py
+++ b/iob_soc.py
@@ -41,6 +41,7 @@ class iob_soc(iob_module):
     version = "V0.70"
     setup_dir = os.path.dirname(__file__)
     rw_overlap = True
+    is_system = True
 
     # IOb-SoC has the following list of non standard attributes:
     peripherals = None  # List with instances peripherals to include in system

--- a/submodules/LIB/scripts/build_srcs.py
+++ b/submodules/LIB/scripts/build_srcs.py
@@ -33,7 +33,8 @@ def flows_setup(python_module):
     syn_setup(python_module)
 
     # Setup software
-    sw_setup(python_module)
+    if python_module.is_system:
+        sw_setup(python_module)
 
     # Setup documentation if it is top module
     doc_setup(python_module)

--- a/submodules/LIB/scripts/build_srcs.py
+++ b/submodules/LIB/scripts/build_srcs.py
@@ -33,8 +33,7 @@ def flows_setup(python_module):
     syn_setup(python_module)
 
     # Setup software
-    if python_module.is_system or python_module.regs:
-        sw_setup(python_module)
+    sw_setup(python_module)
 
     # Setup documentation if it is top module
     doc_setup(python_module)

--- a/submodules/LIB/scripts/build_srcs.py
+++ b/submodules/LIB/scripts/build_srcs.py
@@ -33,7 +33,7 @@ def flows_setup(python_module):
     syn_setup(python_module)
 
     # Setup software
-    if python_module.is_system:
+    if python_module.is_system or python_module.regs:
         sw_setup(python_module)
 
     # Setup documentation if it is top module

--- a/submodules/LIB/scripts/iob_module.py
+++ b/submodules/LIB/scripts/iob_module.py
@@ -37,6 +37,7 @@ class iob_module:
     wire_list = None  # List of internal wires of the Verilog module. Used to interconnect module components.
     is_top_module = False  # Select if this module is the top module
     use_netlist = False  # use module netlist
+    is_system = False  # create software files in build directory
 
     _initialized_attributes = (
         False  # Store if attributes have been initialized for this class
@@ -419,18 +420,19 @@ class iob_module:
     @classmethod
     def _generate_sw(cls, mkregs_obj, reg_table):
         """Generate common software files"""
-        os.makedirs(cls.build_dir + "/software/src", exist_ok=True)
-        if cls.regs:
-            mkregs_obj.write_swheader(
-                reg_table, cls.build_dir + "/software/src", cls.name
-            )
-            mkregs_obj.write_swcode(
-                reg_table, cls.build_dir + "/software/src", cls.name
-            )
-            mkregs_obj.write_swheader(
-                reg_table, cls.build_dir + "/software/src", cls.name
-            )
-        mk_conf.conf_h(cls.confs, cls.name, cls.build_dir + "/software/src")
+        if cls.is_system or cls.regs:
+            os.makedirs(cls.build_dir + "/software/src", exist_ok=True)
+            if cls.regs:
+                mkregs_obj.write_swheader(
+                    reg_table, cls.build_dir + "/software/src", cls.name
+                )
+                mkregs_obj.write_swcode(
+                    reg_table, cls.build_dir + "/software/src", cls.name
+                )
+                mkregs_obj.write_swheader(
+                    reg_table, cls.build_dir + "/software/src", cls.name
+                )
+            mk_conf.conf_h(cls.confs, cls.name, cls.build_dir + "/software/src")
 
     @classmethod
     def _generate_doc(cls, mkregs_obj, reg_table):

--- a/submodules/LIB/scripts/mk_configuration.py
+++ b/submodules/LIB/scripts/mk_configuration.py
@@ -102,8 +102,7 @@ def config_build_mk(python_module):
     file2create.write(f"NAME={python_module.name}\n")
     file2create.write(f"CSR_IF={python_module.csr_if}\n\n")
     file2create.write(f"BUILD_DIR_NAME={python_module.build_dir.split('/')[-1]}\n")
-    if python_module.is_system:
-        file2create.write("IS_FPGA=1\n")
+    file2create.write(f"IS_FPGA={int(python_module.is_system)}\n")
 
     file2create.close()
 

--- a/submodules/LIB/scripts/mk_configuration.py
+++ b/submodules/LIB/scripts/mk_configuration.py
@@ -101,8 +101,9 @@ def config_build_mk(python_module):
     file2create = open(f"{python_module.build_dir}/config_build.mk", "w")
     file2create.write(f"NAME={python_module.name}\n")
     file2create.write(f"CSR_IF={python_module.csr_if}\n\n")
-    file2create.write(f"VERSION={python_module.version}\n")
     file2create.write(f"BUILD_DIR_NAME={python_module.build_dir.split('/')[-1]}\n")
+    if python_module.is_system:
+        file2create.write("IS_FPGA=1\n")
 
     file2create.close()
 

--- a/submodules/LIB/scripts/mk_configuration.py
+++ b/submodules/LIB/scripts/mk_configuration.py
@@ -66,6 +66,8 @@ def conf_vh(macros, top_module, out_dir):
 
 
 def conf_h(macros, top_module, out_dir):
+    if len(macros) == 0:
+        return
     os.makedirs(out_dir, exist_ok=True)
     file2create = open(f"{out_dir}/{top_module}_conf.h", "w")
     core_prefix = f"{top_module}_".upper()


### PR DESCRIPTION
The new `is_system` attribute, when set, causes the copy/generation of software and related files during the setup process.
It also add the `IS_FPGA` makefile variable to the `config_build.mk` file of the build directory.

Related to discussion in https://github.com/IObundle/iob-soc/pull/727