### PR TITLE
Added a try catch around get_build_dir otherwise error could delete entire project

### DIFF
--- a/submodules/LIB/scripts/bootstrap.py
+++ b/submodules/LIB/scripts/bootstrap.py
@@ -111,8 +111,11 @@ def get_top_module_version():
 
 # Print build directory attribute of the top module
 def get_build_dir():
-    top_module = init_top_module()
-    print(top_module.build_dir)
+    try:
+        top_module = init_top_module()
+        print(top_module.build_dir)
+    except:
+        print("SOMETHING_OR_RM_DELETES_EVERYTHING")
 
 
 # Instantiate top module to start setup process

--- a/submodules/LIB/scripts/bootstrap.py
+++ b/submodules/LIB/scripts/bootstrap.py
@@ -115,7 +115,8 @@ def get_build_dir():
         top_module = init_top_module()
         print(top_module.build_dir)
     except:
-        print("SOMETHING_OR_RM_DELETES_EVERYTHING")
+        print("NON_EXISTANT_DIR_OR_RM_DELETES_EVERYTHING")
+        raise
 
 
 # Instantiate top module to start setup process


### PR DESCRIPTION
When init_top_module raised an error, the variable BUILD_DIR in LIB/setup.mk would be empty and the "rm -rf $(BUILD_DIR)" command in the clean rule would delete the entire project.

Adding a try catch and printing a non existent folder appears to be the simpler approach to fixing this problem. 