### PR TITLE
rom putted in the top with sucess

### DIFF
--- a/hardware/common_src/iob_soc_mwrap.v
+++ b/hardware/common_src/iob_soc_mwrap.v
@@ -18,6 +18,7 @@
 
 
 module iob_soc_mwrap #(
+    parameter BOOT_HEXFILE = "iob_soc_boot",
    `include "iob_soc_params.vs"
 ) (
    `include "iob_soc_io.vs"
@@ -88,9 +89,36 @@ iob_soc #(
     .uart_txd_o(                   uart_txd_o),
     .uart_rxd_i(                   uart_rxd_i),
     .uart_cts_i(                   uart_cts_i),
-    .uart_rts_o(                   uart_rts_o)
+    .uart_rts_o(                   uart_rts_o),
+    //rom
+    .rom_r_valid(rom_r_valid),
+    .rom_r_addr(rom_r_addr),
+    .rom_r_rdata(rom_r_rdata)
+    //
 );
 
+
+    //rom wires
+    wire                      rom_r_valid;
+    wire [BOOTROM_ADDR_W-3:0] rom_r_addr;
+    wire [DATA_W-1:0]         rom_r_rdata;
+    //
+
+
+
+
+
+    //rom instatiation
+   iob_rom_sp #(
+      .DATA_W (DATA_W),
+      .ADDR_W (BOOTROM_ADDR_W - 2),
+      .HEXFILE({BOOT_HEXFILE, ".hex"})
+   ) sp_rom0 (
+      .clk_i   (clk_i),
+      .r_en_i  (rom_r_valid),
+      .addr_i  (rom_r_addr),
+      .r_data_o(rom_r_rdata)
+   );
 
 
 

--- a/hardware/src/iob_soc.v
+++ b/hardware/src/iob_soc.v
@@ -11,6 +11,13 @@
 module iob_soc #(
    `include "iob_soc_params.vs"
 ) (
+
+
+   //rom
+   output reg                       rom_r_valid,
+   output reg  [BOOTROM_ADDR_W-3:0] rom_r_addr,
+   input       [DATA_W-1:0]         rom_r_rdata,
+   //
    `include "iob_soc_io.vs"
 );
 
@@ -180,7 +187,12 @@ module iob_soc #(
 
       //data bus
       .d_req_i (slaves_req[0+:`REQ_W]),
-      .d_resp_o(slaves_resp[0+:`RESP_W])
+      .d_resp_o(slaves_resp[0+:`RESP_W]),
+      //rom
+      .rom_r_valid(rom_r_valid),
+      .rom_r_addr(rom_r_addr),
+      .rom_r_rdata(rom_r_rdata)
+      //
    );
 
 `ifdef IOB_SOC_USE_EXTMEM

--- a/hardware/src/iob_soc_boot_ctr.v
+++ b/hardware/src/iob_soc_boot_ctr.v
@@ -25,6 +25,13 @@ module iob_soc_boot_ctr #(
    output     [  DATA_W-1:0] sram_wdata_o,
    output reg [DATA_W/8-1:0] sram_wstrb_o,
 
+   //rom
+   output reg                       rom_r_valid,
+   output reg  [BOOTROM_ADDR_W-3:0] rom_r_addr,
+   input       [DATA_W-1:0]         rom_r_rdata,
+   //
+
+
    `include "clk_en_rst_s_port.vs"
 );
 
@@ -93,9 +100,6 @@ module iob_soc_boot_ctr #(
    //
    // READ BOOT ROM 
    //
-   reg                       rom_r_valid;
-   reg  [BOOTROM_ADDR_W-3:0] rom_r_addr;
-   wire [        DATA_W-1:0] rom_r_rdata;
 
    always @(posedge clk_i, posedge arst_i)
       if (arst_i) begin
@@ -137,15 +141,6 @@ module iob_soc_boot_ctr #(
    //
    //INSTANTIATE ROM
    //
-   iob_rom_sp #(
-      .DATA_W (DATA_W),
-      .ADDR_W (BOOTROM_ADDR_W - 2),
-      .HEXFILE(HEXFILE)
-   ) sp_rom0 (
-      .clk_i   (clk_i),
-      .r_en_i  (rom_r_valid),
-      .addr_i  (rom_r_addr),
-      .r_data_o(rom_r_rdata)
-   );
+
 
 endmodule

--- a/hardware/src/iob_soc_int_mem.v
+++ b/hardware/src/iob_soc_int_mem.v
@@ -23,6 +23,13 @@ module iob_soc_int_mem #(
    //data bus
    input  [ `REQ_W-1:0] d_req_i,
    output [`RESP_W-1:0] d_resp_o,
+
+   //rom
+   output reg                       rom_r_valid,
+   output reg  [BOOTROM_ADDR_W-3:0] rom_r_addr,
+   input       [DATA_W-1:0]         rom_r_rdata,
+   //
+
    `include "clk_en_rst_s_port.vs"
 );
 
@@ -96,7 +103,12 @@ module iob_soc_int_mem #(
       .sram_valid_o(ram_w_req[`VALID(0)]),
       .sram_addr_o  (ram_w_req[`ADDRESS(0, ADDR_W)]),
       .sram_wdata_o (ram_w_req[`WDATA(0)]),
-      .sram_wstrb_o (ram_w_req[`WSTRB(0)])
+      .sram_wstrb_o (ram_w_req[`WSTRB(0)]),
+      //rom
+      .rom_r_valid(rom_r_valid),
+      .rom_r_addr(rom_r_addr),
+      .rom_r_rdata(rom_r_rdata)
+      //
    );
 
    //


### PR DESCRIPTION
Rom putted in the mem wrapper, wires and io were added to the required modules, and added a new parameter to the top called boot_hex(it already existed in other models) but is added as a parameter to the memwrapper.


simulations and fpga test were sucessefull