### PR TITLE
fix(sim): fix iob-soc simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,19 +39,19 @@ setup:
 	$(call IOB_NIX_ENV, make build-setup SETUP_ARGS="$(SETUP_ARGS)")
 
 pc-emul-run:
-	$(call IOB_NIX_ENV, make clean setup && make -C ../$(CORE)_V*/ pc-emul-run)
+	$(call IOB_NIX_ENV, make clean setup && make -C ../$(CORE)_V*/build/ pc-emul-run)
 
 pc-emul-test:
-	$(call IOB_NIX_ENV, make clean setup && make -C ../$(CORE)_V*/ pc-emul-run)
+	$(call IOB_NIX_ENV, make clean setup && make -C ../$(CORE)_V*/build/ pc-emul-run)
 
 sim-run:
 	$(call IOB_NIX_ENV, make clean setup INIT_MEM=$(INIT_MEM) USE_EXTMEM=$(USE_EXTMEM) && make -C ../$(CORE)_V*/ fw-build)
 	$(call IOB_NIX_ENV, make clean setup INIT_MEM=$(INIT_MEM) USE_EXTMEM=$(USE_EXTMEM) && make -C ../$(CORE)_V*/ sim-run SIMULATOR=$(SIMULATOR))
 
 sim-test:
-	$(call IOB_NIX_ENV, make clean setup INIT_MEM=1 USE_EXTMEM=0 && make -C ../$(CORE)_V*/ sim-run SIMULATOR=icarus)
-	$(call IOB_NIX_ENV, make clean setup INIT_MEM=0 USE_EXTMEM=1 && make -C ../$(CORE)_V*/ sim-run SIMULATOR=verilator)
-	$(call IOB_NIX_ENV, make clean setup INIT_MEM=0 USE_EXTMEM=1 && make -C ../$(CORE)_V*/ sim-run SIMULATOR=verilator)
+	$(call IOB_NIX_ENV, make clean setup INIT_MEM=1 USE_EXTMEM=0 && make -C ../$(CORE)_V*/build/ sim-run SIMULATOR=icarus)
+	$(call IOB_NIX_ENV, make clean setup INIT_MEM=0 USE_EXTMEM=1 && make -C ../$(CORE)_V*/build/ sim-run SIMULATOR=verilator)
+	$(call IOB_NIX_ENV, make clean setup INIT_MEM=0 USE_EXTMEM=1 && make -C ../$(CORE)_V*/build/ sim-run SIMULATOR=verilator)
 
 fpga-run:
 	$(call IOB_NIX_ENV, make clean setup INIT_MEM=$(INIT_MEM) USE_EXTMEM=$(USE_EXTMEM) && make -C ../$(CORE)_V*/ fpga-fw-build BOARD=$(BOARD))

--- a/hardware/simulation/src/iob_soc_sim_wrapper.v
+++ b/hardware/simulation/src/iob_soc_sim_wrapper.v
@@ -2,6 +2,7 @@
 
 `include "bsp.vh"
 `include "iob_soc_conf.vh"
+`include "iob_uart_swreg_def.vh"
 
 //Peripherals _swreg_def.vh file includes.
 `include "iob_soc_periphs_swreg_def.vs"
@@ -41,7 +42,7 @@ module iob_soc_sim_wrapper (
    output                             uart_rvalid_o
 );
 
-   localparam AXI_ID_W = 4;
+   localparam AXI_ID_W = 1;
    localparam AXI_LEN_W = 8;
    localparam AXI_ADDR_W = `DDR_ADDR_W;
    localparam AXI_DATA_W = `DDR_DATA_W;
@@ -122,10 +123,10 @@ module iob_soc_sim_wrapper (
       .iob_rvalid_o(uart_rvalid_o),
       .iob_ready_o (uart_ready_o),
 
-      .txd_o(uart_rxd_i),
-      .rxd_i(uart_txd_o),
-      .rts_o(uart_cts_i),
-      .cts_i(uart_rts_o)
+      .txd_o(uart_rxd),
+      .rxd_i(uart_txd),
+      .rts_o(uart_cts),
+      .cts_i(uart_rts)
    );
 
    //Ethernet

--- a/lib/hardware/simulation/verilator.mk
+++ b/lib/hardware/simulation/verilator.mk
@@ -4,7 +4,7 @@ VFLAGS+=--cc --exe -I. -I../src -Isrc --top-module $(VTOP)
 VFLAGS+=-Wno-lint --Wno-UNOPTFLAT
 VFLAGS+=--no-timing
 # Include embedded headers
-VFLAGS+=-CFLAGS "-I../../../software/src -I../../../software"
+VFLAGS+=-CFLAGS "-I../../../software/src -I../../../software/include -I../../../software"
 
 ifeq ($(VCD),1)
 VFLAGS+=--trace

--- a/lib/scripts/if_gen.py
+++ b/lib/scripts/if_gen.py
@@ -710,14 +710,31 @@ def write_s_port(fout, port_prefix, param_prefix, port_list):
 #
 
 
-# Write single port with given direction, bus width, and name to file
-def write_portmap(fout, port_prefix, wire_prefix, direction, port, connect_to_port):
+def get_port_name(port_prefix, direction, port):
     suffix = get_suffix(direction)
     port_name = port_prefix + port["name"] + suffix
+    return (suffix, port_name)
+
+
+# Generate portmap string for a single port given direction, but width and name
+def get_portmap_string(port_prefix, wire_prefix, direction, port, connect_to_port):
+    suffix, port_name = get_port_name(port_prefix, direction, port)
     wire_name = wire_prefix + port["name"]
     if connect_to_port:
         wire_name = wire_name + suffix
-    fout.write("." + port_name + "(" + wire_name + ")," + "\n")
+    return f".{port_name}({wire_name}),\n"
+
+
+# Write single port with to file
+def write_portmap(fout, port_prefix, wire_prefix, direction, port, connect_to_port):
+    portmap_string = get_portmap_string(
+        port_prefix,
+        wire_prefix,
+        direction,
+        port,
+        connect_to_port,
+    )
+    fout.write(portmap_string)
 
 
 def write_m_portmap(fout, port_prefix, wire_prefix, port_list):

--- a/lib/scripts/iob_soc_create_wrapper_files.py
+++ b/lib/scripts/iob_soc_create_wrapper_files.py
@@ -2,6 +2,7 @@ import os
 
 from submodule_utils import add_prefix_to_parameters_in_string
 from iob_soc_peripherals import get_pio_signals
+from if_gen import get_portmap_string
 
 
 # Creates the Verilog Snippet (.vs) files required by wrappers
@@ -44,8 +45,14 @@ def create_wrapper_files(build_dir, name, ios, confs, num_extmem_connections):
         if pio_signals and "if_defined" in table.keys():
             pportmaps_str += f"`ifdef {table['if_defined']}\n"
         for signal in pio_signals:
-            pportmaps_str += "               .{signal}({signal}),\n".format(
-                signal=signal["name"]
+            pportmaps_str += "               {signal_portmap}".format(
+                signal_portmap=get_portmap_string(
+                    port_prefix="",
+                    wire_prefix="",
+                    direction=signal["direction"],
+                    port=signal,
+                    connect_to_port=False,
+                )
             )
         if pio_signals and "if_defined" in table.keys():
             pportmaps_str += "`endif\n"

--- a/lib/scripts/iob_soc_peripherals.py
+++ b/lib/scripts/iob_soc_peripherals.py
@@ -438,8 +438,15 @@ def get_peripheral_blocks(peripherals_str, root_dir):
 
 # peripheral_instance: dictionary describing a peripheral instance. Must have 'name' and 'IO' attributes.
 # port_name: name of the port we are mapping
-def get_peripheral_port_mapping(peripheral_instance, if_name, port_name):
+def get_peripheral_port_mapping(
+    peripheral_portmaps, peripheral_instance, if_name, port_name
+):
     print(peripheral_instance, if_name, port_name)
+    # try to match port map from peripheral_portmap list
+    for portmap in peripheral_portmaps:
+        if portmap[0]["corename"] == peripheral_instance.name:
+            if portmap[0]["if_name"] == if_name and portmap[0]["port"] == port_name:
+                return portmap[1]["port"]
     # If IO dictionary (with mapping) does not exist for this peripheral, use default wire name
     if "io" not in peripheral_instance.__dict__:
         return f"{peripheral_instance.name}_{port_name}"

--- a/lib/scripts/iob_soc_utils.py
+++ b/lib/scripts/iob_soc_utils.py
@@ -147,6 +147,7 @@ def iob_soc_hw_setup(python_module, exclude_files=[]):
             build_dir,
             name,
             peripherals_list,
+            python_module.peripheral_portmap,
             internal_wires=python_module.internal_wires,
         )
 

--- a/lib/software/Makefile
+++ b/lib/software/Makefile
@@ -48,7 +48,7 @@ EMUL_CFLAGS ?=-Os -std=gnu99 -Wl,--strip-debug
 
 CONSOLE_CMD ?=rm -f soc2cnsl cnsl2soc; ../scripts/console.py -L
 
-EMUL_INCLUDES ?=-I. -Isrc
+EMUL_INCLUDES ?=-I. -Isrc -Iinclude
 
 EMUL_HDR+=$(wildcard src/*_emul.h)
 

--- a/software/sw_build.mk
+++ b/software/sw_build.mk
@@ -32,7 +32,7 @@ UTARGETS+=build_iob_soc_software
 
 TEMPLATE_LDS=src/$@.lds
 
-IOB_SOC_INCLUDES=-I. -Isrc 
+IOB_SOC_INCLUDES=-I. -Isrc -Iinclude
 
 IOB_SOC_LFLAGS=-Wl,-Bstatic,-T,$(TEMPLATE_LDS),--strip-debug
 


### PR DESCRIPTION
- update if_gen2 branch to run iob_soc simulation
- add missing `software/include` path for compilation (some .h files are generated in that folder)
- update BUILD_DIR path in top level makefile: now in `../CORE_VERSION/build` by default
- refactor if_gen.py to have functions to only generate verilog wire portmap strings - instead on only writting to file, we can pass the strings to other scripts
- fixes to peripheral portmaps - use correct sufix in port name - use custom peripheral_portmap, if exists
* * *
- fixing simulation to work on removing the REQ/RESP macros and leverate if_gen.py to generate wires and portmaps for iob native buses 