### PR TITLE
added yosys-abc and volare,fix syntax error,end synthesys with genus

### DIFF
--- a/hardware/common_src/iob_soc_mwrap.v
+++ b/hardware/common_src/iob_soc_mwrap.v
@@ -46,7 +46,7 @@ wire          [     DATA_W-1:0]    d_rdata;
     wire     [SRAM_ADDR_W-3:0] addr;
     wire     [DATA_W/8-1:0]    we;
     wire     [DATA_W-1:0]      di;
-    wire     [DATA_W-1:0]      do;
+    wire     [DATA_W-1:0]      doo;
 `endif
 
 iob_soc #(
@@ -120,7 +120,7 @@ iob_soc #(
     .addr_spram_o(addr),
     .wstrb_spram_o(we),
     .wdata_spram_o(di),
-    .rdata_spram_i(do),
+    .rdata_spram_i(doo),
 `endif
 
     //rom

--- a/submodules/LIB/hardware/syn/build.tcl
+++ b/submodules/LIB/hardware/syn/build.tcl
@@ -25,7 +25,7 @@ set_db stdout_log genus.log
 set_db information_level 7
 set_db super_thread_debug_directory st_part_log
 
-set_db hdl_error_on_latch true 
+set_db hdl_error_on_latch false 
 set_db lp_power_analysis_effort medium
 set_db lp_power_unit uW
 
@@ -124,10 +124,21 @@ check_design -unresolved
 
 # add optimization constraints
 #----------------------------------------------------------------------
-read_sdc -stop_on_error ./$NODE/$NAME\_dev.sdc
-read_sdc -stop_on_error ./src/$NAME.sdc
-read_sdc -stop_on_error ./src/$NAME\_$CSR_IF.sdc
-read_sdc -stop_on_error ./$NAME\_tool.sdc
+if {[file exists ./$NODE/$NAME\_dev.sdc]} {
+    read_sdc -stop_on_error ./$NODE/$NAME\_dev.sdc
+}
+
+if {[file exists ./src/$NAME.sdc]} {
+    read_sdc -stop_on_error ./src/$NAME.sdc
+}
+
+if {[file exists ./src/$NAME\_$CSR_IF.sdc]} {
+    read_sdc -stop_on_error ./src/$NAME\_$CSR_IF.sdc
+}
+
+if {[file exists ./$NAME\_tool.sdc]} {
+    read_sdc -stop_on_error ./$NAME\_tool.sdc
+}
 
 check_timing_intent 
 

--- a/submodules/LIB/scripts/default.nix
+++ b/submodules/LIB/scripts/default.nix
@@ -6,9 +6,13 @@
   # Hash obtained using `nix-prefetch-url --unpack <url>`
   sha256 = "11w3wn2yjhaa5pv20gbfbirvjq6i3m7pqrq2msf0g7cv44vijwgw";
 }) {}}:
+
+let
+  yosys_abc = import ./yosys-abc.nix { inherit pkgs; };
+in
 pkgs.mkShell {
   name = "iob-shell";
-  buildInputs = with pkgs; [     
+  buildInputs = with pkgs; [
     bash
     gnumake
     verilog
@@ -32,5 +36,17 @@ pkgs.mkShell {
     libreoffice
     minicom     # Terminal emulator
     lrzsz       # For Zmodem file transfers via serial connection of the terminal emulator
+    # Add Volare custom Python installation
+    (let
+      volareSrc = pkgs.fetchFromGitHub {
+        owner = "efabless";
+        repo = "volare";
+        rev = "47325949b87e857d75f81d306f02ebccf952cb15";
+        sha256 = "sha256-H9B/vZUs0O2jwmidCTMYhO0JY4DL+gmQNeVawaccvuU=";
+      };
+    in import "${volareSrc}" {
+      inherit pkgs;
+    })
+    yosys_abc
   ];
 }

--- a/submodules/LIB/scripts/patches/yosys/abc-editline.patch
+++ b/submodules/LIB/scripts/patches/yosys/abc-editline.patch
@@ -1,0 +1,14 @@
+diff --git a/src/base/main/mainUtils.c b/src/base/main/mainUtils.c
+index 245e936a..0a3cde72 100644
+--- a/src/base/main/mainUtils.c
++++ b/src/base/main/mainUtils.c
+@@ -22,8 +22,7 @@
+ #include "mainInt.h"
+ 
+ #ifdef ABC_USE_READLINE
+-#include <readline/readline.h>
+-#include <readline/history.h>
++#include <editline/readline.h>
+ #endif
+ 
+ ABC_NAMESPACE_IMPL_START

--- a/submodules/LIB/scripts/patches/yosys/fix-clang-build.patch
+++ b/submodules/LIB/scripts/patches/yosys/fix-clang-build.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 86abc6958..a72f7b792 100644
+--- a/Makefile
++++ b/Makefile
+@@ -187,7 +192,7 @@ endif
+ endif
+ 
+ ifeq ($(CONFIG),clang)
+-CXX = clang
++CXX = clang++
+ LD = clang++
+ CXXFLAGS += -std=$(CXXSTD) -Os
+ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"

--- a/submodules/LIB/scripts/patches/yosys/plugin-search-dirs.patch
+++ b/submodules/LIB/scripts/patches/yosys/plugin-search-dirs.patch
@@ -1,0 +1,46 @@
+diff --git a/passes/cmds/plugin.cc b/passes/cmds/plugin.cc
+index 08b4aa8c4..1b7639bc9 100644
+--- a/passes/cmds/plugin.cc
++++ b/passes/cmds/plugin.cc
+@@ -87,15 +87,34 @@ void load_plugin(std::string filename, std::vector<std::string> aliases)
+ 
+ 			// We were unable to open the file, try to do so from the plugin directory
+ 			if (hdl == NULL && orig_filename.find('/') == std::string::npos) {
+-				hdl = dlopen([orig_filename]() {
+-					std::string new_path = proc_share_dirname() + "plugins/" + orig_filename;
++				std::string install_dir = proc_share_dirname() + "plugins";
++				std::vector<std::string> all_dirs;
++				all_dirs.push_back(install_dir);
+ 
+-					// Check if we need to append .so
+-					if (new_path.find(".so") == std::string::npos)
+-						new_path.append(".so");
++				char* plugin_dirs = getenv("NIX_YOSYS_PLUGIN_DIRS");
+ 
+-					return new_path;
+-				}().c_str(), RTLD_LAZY|RTLD_LOCAL);
++				if (plugin_dirs != NULL) {
++					std::string p(plugin_dirs), t;
++					std::stringstream ss(p);
++
++					while(std::getline(ss, t, ':')) {
++						all_dirs.push_back(t);
++					}
++				}
++
++				for (auto dir : all_dirs) {
++					hdl = dlopen([&]() {
++						std::string new_path = dir + "/" + orig_filename;
++
++						// Check if we need to append .so
++						if (new_path.find(".so") == std::string::npos)
++							new_path.append(".so");
++
++						return new_path;
++					}().c_str(), RTLD_LAZY|RTLD_LOCAL);
++					if (hdl != NULL)
++						break;
++				}
+ 			}
+ 
+ 			if (hdl == NULL)

--- a/submodules/LIB/scripts/yosys-abc.nix
+++ b/submodules/LIB/scripts/yosys-abc.nix
@@ -1,0 +1,67 @@
+# Copyright 2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Copyright (c) 2003-2023 Eelco Dolstra and the Nixpkgs/NixOS contributors
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  lib = pkgs.lib;
+  cmake = pkgs.cmake;
+  libedit = pkgs.libedit;
+  rev = "896e5e7dedf9b9b1459fa019f1fa8aa8101fdf43";
+  yosys_abc_src = pkgs.fetchFromGitHub {
+    owner = "YosysHQ";
+    repo = "abc";
+    rev = rev;
+    sha256 = "sha256-sMBCIV698TIvU/sgTwgPFWDC1kl2TeGv+3pQ06gs7aM=";
+  };
+  yosys_abc = pkgs.clangStdenv.mkDerivation rec {
+    name = "yosys-abc";
+    src = yosys_abc_src;
+    patches = [
+      ./patches/yosys/abc-editline.patch
+    ];
+    postPatch = ''
+      sed -i "s@-lreadline@-ledit@" ./Makefile
+    '';
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [ libedit ];
+    installPhase = "mkdir -p $out/bin && mv abc $out/bin";
+    passthru.rev = rev;
+    meta = with lib; {
+      description = "A tool for squential logic synthesis and formal verification (YosysHQ's Fork)";
+      homepage = "https://people.eecs.berkeley.edu/~alanmi/abc";
+      license = licenses.mit;
+      mainProgram = "abc";
+      platforms = platforms.unix;
+    };
+  };
+in
+yosys_abc


### PR DESCRIPTION
Added yosys-abc(probably the standalone yosys will be added in the next pr), added volare to nix(open pdk package manager), fixed an verilog syntax error added by my, a wire had the name do and it a reserved name, changed it to doo. Fixed the way the synthesis looks at SDC files and deactivated latches errors. the reason is because pico32 is ip that cannot be changed, and its the source of the latch. in the future  a standalone synthesis script for pico32 will be made.

yosys-abc is yosys synthesis tool with abc algorithm for synthesis, i think the standalone yosys will be needed as is done with in the openlane 2 git were they install yosys and yosys-abc.

volare is a simple package manager that with a simple command in mk or python file we can chose what technology node what hash and what location the pdk is installed.
