### PR TITLE
added yosys-abc and volare,fix syntax error ,end synthesys with genus

### DIFF
--- a/hardware/common_src/iob_soc_mwrap.v
+++ b/hardware/common_src/iob_soc_mwrap.v
@@ -42,11 +42,11 @@ wire          [     DATA_W-1:0]    d_rdata;
 //
 
 `ifdef USE_SPRAM
-    wire                       en;
-    wire     [SRAM_ADDR_W-3:0] addr;
-    wire     [DATA_W/8-1:0]    we;
-    wire     [DATA_W-1:0]      di;
-    wire     [DATA_W-1:0]      do;
+    wire                       spram_en;
+    wire     [SRAM_ADDR_W-3:0] spram_addr;
+    wire     [DATA_W/8-1:0]    spram_we;
+    wire     [DATA_W-1:0]      spram_di;
+    wire     [DATA_W-1:0]      spram_do;
 `endif
 
 iob_soc #(
@@ -116,11 +116,11 @@ iob_soc #(
     .uart_rts_o(                   uart_rts_o),
         //SPRAM  
 `ifdef USE_SPRAM
-    .valid_spram_o(en),
-    .addr_spram_o(addr),
-    .wstrb_spram_o(we),
-    .wdata_spram_o(di),
-    .rdata_spram_i(do),
+    .valid_spram_o(spram_en),
+    .addr_spram_o(spram_addr),
+    .wstrb_spram_o(spram_we),
+    .wdata_spram_o(spram_di),
+    .rdata_spram_i(spram_do),
 `endif
 
     //rom
@@ -153,11 +153,11 @@ iob_soc #(
         ) main_mem_byte (
             .clk_i(clk_i),
             // data port
-            .en_i  (en),
-            .addr_i(addr),
-            .we_i  (wstrb),
-            .d_i   (wdata),
-            .dt_o  (rdata)
+            .en_i  (spram_en),
+            .addr_i(spram_addr),
+            .we_i  (spram_we),
+            .d_i   (spram_di),
+            .dt_o  (spram_do)
         );
     `else
         `ifdef IOB_MEM_NO_READ_ON_WRITE

--- a/hardware/syn/syn_build.tcl
+++ b/hardware/syn/syn_build.tcl
@@ -1,0 +1,1 @@
+set_db hdl_error_on_latch false

--- a/submodules/LIB/hardware/syn/build.tcl
+++ b/submodules/LIB/hardware/syn/build.tcl
@@ -24,8 +24,10 @@ set_db init_hdl_search_path $INCLUDE
 set_db stdout_log genus.log
 set_db information_level 7
 set_db super_thread_debug_directory st_part_log
-
-set_db hdl_error_on_latch true 
+set_db hdl_error_on_latch true
+if {[file exists "syn_build.tcl"]} {
+    source "syn_build.tcl"
+}
 set_db lp_power_analysis_effort medium
 set_db lp_power_unit uW
 
@@ -124,10 +126,21 @@ check_design -unresolved
 
 # add optimization constraints
 #----------------------------------------------------------------------
-read_sdc -stop_on_error ./$NODE/$NAME\_dev.sdc
-read_sdc -stop_on_error ./src/$NAME.sdc
-read_sdc -stop_on_error ./src/$NAME\_$CSR_IF.sdc
-read_sdc -stop_on_error ./$NAME\_tool.sdc
+if {[file exists ./$NODE/$NAME\_dev.sdc]} {
+    read_sdc -stop_on_error ./$NODE/$NAME\_dev.sdc
+}
+
+if {[file exists ./src/$NAME.sdc]} {
+    read_sdc -stop_on_error ./src/$NAME.sdc
+}
+
+if {[file exists ./src/$NAME\_$CSR_IF.sdc]} {
+    read_sdc -stop_on_error ./src/$NAME\_$CSR_IF.sdc
+}
+
+if {[file exists ./$NAME\_tool.sdc]} {
+    read_sdc -stop_on_error ./$NAME\_tool.sdc
+}
 
 check_timing_intent 
 

--- a/submodules/LIB/scripts/default.nix
+++ b/submodules/LIB/scripts/default.nix
@@ -6,9 +6,13 @@
   # Hash obtained using `nix-prefetch-url --unpack <url>`
   sha256 = "11w3wn2yjhaa5pv20gbfbirvjq6i3m7pqrq2msf0g7cv44vijwgw";
 }) {}}:
+
+let
+  yosys = import ./yosys.nix { inherit pkgs; };
+in
 pkgs.mkShell {
   name = "iob-shell";
-  buildInputs = with pkgs; [     
+  buildInputs = with pkgs; [
     bash
     gnumake
     verilog
@@ -32,5 +36,17 @@ pkgs.mkShell {
     libreoffice
     minicom     # Terminal emulator
     lrzsz       # For Zmodem file transfers via serial connection of the terminal emulator
+    # Add Volare custom Python installation
+    (let
+      volareSrc = pkgs.fetchFromGitHub {
+        owner = "efabless";
+        repo = "volare";
+        rev = "47325949b87e857d75f81d306f02ebccf952cb15";
+        sha256 = "sha256-H9B/vZUs0O2jwmidCTMYhO0JY4DL+gmQNeVawaccvuU=";
+      };
+    in import "${volareSrc}" {
+      inherit pkgs;
+    })
+    yosys
   ];
 }

--- a/submodules/LIB/scripts/iob_module.py
+++ b/submodules/LIB/scripts/iob_module.py
@@ -740,12 +740,6 @@ class iob_module:
                             ),
                         )
                         continue
-                elif directory == "hardware/common_src":
-                    shutil.copytree(
-                        os.path.join(os.getcwd(), directory),
-                        os.path.join(cls.build_dir, directory),
-                        dirs_exist_ok=False,
-                    )
                 elif directory == "hardware/fpga":
                     # Skip if board_list is empty
                     if cls.board_list is None:

--- a/submodules/LIB/scripts/patches/yosys/abc-editline.patch
+++ b/submodules/LIB/scripts/patches/yosys/abc-editline.patch
@@ -1,0 +1,14 @@
+diff --git a/src/base/main/mainUtils.c b/src/base/main/mainUtils.c
+index 245e936a..0a3cde72 100644
+--- a/src/base/main/mainUtils.c
++++ b/src/base/main/mainUtils.c
+@@ -22,8 +22,7 @@
+ #include "mainInt.h"
+ 
+ #ifdef ABC_USE_READLINE
+-#include <readline/readline.h>
+-#include <readline/history.h>
++#include <editline/readline.h>
+ #endif
+ 
+ ABC_NAMESPACE_IMPL_START

--- a/submodules/LIB/scripts/patches/yosys/fix-clang-build.patch
+++ b/submodules/LIB/scripts/patches/yosys/fix-clang-build.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 86abc6958..a72f7b792 100644
+--- a/Makefile
++++ b/Makefile
+@@ -187,7 +192,7 @@ endif
+ endif
+ 
+ ifeq ($(CONFIG),clang)
+-CXX = clang
++CXX = clang++
+ LD = clang++
+ CXXFLAGS += -std=$(CXXSTD) -Os
+ ABCMKARGS += ARCHFLAGS="-DABC_USE_STDINT_H"

--- a/submodules/LIB/scripts/patches/yosys/plugin-search-dirs.patch
+++ b/submodules/LIB/scripts/patches/yosys/plugin-search-dirs.patch
@@ -1,0 +1,46 @@
+diff --git a/passes/cmds/plugin.cc b/passes/cmds/plugin.cc
+index 08b4aa8c4..1b7639bc9 100644
+--- a/passes/cmds/plugin.cc
++++ b/passes/cmds/plugin.cc
+@@ -87,15 +87,34 @@ void load_plugin(std::string filename, std::vector<std::string> aliases)
+ 
+ 			// We were unable to open the file, try to do so from the plugin directory
+ 			if (hdl == NULL && orig_filename.find('/') == std::string::npos) {
+-				hdl = dlopen([orig_filename]() {
+-					std::string new_path = proc_share_dirname() + "plugins/" + orig_filename;
++				std::string install_dir = proc_share_dirname() + "plugins";
++				std::vector<std::string> all_dirs;
++				all_dirs.push_back(install_dir);
+ 
+-					// Check if we need to append .so
+-					if (new_path.find(".so") == std::string::npos)
+-						new_path.append(".so");
++				char* plugin_dirs = getenv("NIX_YOSYS_PLUGIN_DIRS");
+ 
+-					return new_path;
+-				}().c_str(), RTLD_LAZY|RTLD_LOCAL);
++				if (plugin_dirs != NULL) {
++					std::string p(plugin_dirs), t;
++					std::stringstream ss(p);
++
++					while(std::getline(ss, t, ':')) {
++						all_dirs.push_back(t);
++					}
++				}
++
++				for (auto dir : all_dirs) {
++					hdl = dlopen([&]() {
++						std::string new_path = dir + "/" + orig_filename;
++
++						// Check if we need to append .so
++						if (new_path.find(".so") == std::string::npos)
++							new_path.append(".so");
++
++						return new_path;
++					}().c_str(), RTLD_LAZY|RTLD_LOCAL);
++					if (hdl != NULL)
++						break;
++				}
+ 			}
+ 
+ 			if (hdl == NULL)

--- a/submodules/LIB/scripts/yosys-abc.nix
+++ b/submodules/LIB/scripts/yosys-abc.nix
@@ -1,0 +1,67 @@
+# Copyright 2023 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Copyright (c) 2003-2023 Eelco Dolstra and the Nixpkgs/NixOS contributors
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  lib = pkgs.lib;
+  cmake = pkgs.cmake;
+  libedit = pkgs.libedit;
+  rev = "896e5e7dedf9b9b1459fa019f1fa8aa8101fdf43";
+  yosys_abc_src = pkgs.fetchFromGitHub {
+    owner = "YosysHQ";
+    repo = "abc";
+    rev = rev;
+    sha256 = "sha256-sMBCIV698TIvU/sgTwgPFWDC1kl2TeGv+3pQ06gs7aM=";
+  };
+  yosys_abc = pkgs.clangStdenv.mkDerivation rec {
+    name = "yosys-abc";
+    src = yosys_abc_src;
+    patches = [
+      ./patches/yosys/abc-editline.patch
+    ];
+    postPatch = ''
+      sed -i "s@-lreadline@-ledit@" ./Makefile
+    '';
+    nativeBuildInputs = [ cmake ];
+    buildInputs = [ libedit ];
+    installPhase = "mkdir -p $out/bin && mv abc $out/bin";
+    passthru.rev = rev;
+    meta = with lib; {
+      description = "A tool for squential logic synthesis and formal verification (YosysHQ's Fork)";
+      homepage = "https://people.eecs.berkeley.edu/~alanmi/abc";
+      license = licenses.mit;
+      mainProgram = "abc";
+      platforms = platforms.unix;
+    };
+  };
+in
+yosys_abc

--- a/submodules/LIB/scripts/yosys.nix
+++ b/submodules/LIB/scripts/yosys.nix
@@ -1,0 +1,111 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  yosys_abc = import ./yosys-abc.nix { inherit pkgs; };
+
+  symlinkJoin = pkgs.symlinkJoin;
+  python3 = pkgs.python3;
+  lib = pkgs.lib;
+  makeWrapper = pkgs.makeWrapper;
+  clangStdenv = pkgs.clangStdenv;
+  fetchFromGitHub = pkgs.fetchFromGitHub;
+  pkg-config = pkgs.pkg-config;
+  bison = pkgs.bison;
+  flex = pkgs.flex;
+  tcl = pkgs.tcl;
+  libedit = pkgs.libedit;
+  libbsd = pkgs.libbsd;
+  libffi = pkgs.libffi;
+  zlib = pkgs.zlib;
+
+  py3env = python3.withPackages (pp:
+    with pp; [
+      click
+      xmlschema
+    ]);
+  
+  yosys = clangStdenv.mkDerivation rec {
+    name = "yosys";
+
+    src = fetchFromGitHub {
+      owner = "YosysHQ";
+      repo = "yosys";
+      rev = "543faed9c8cd7c33bbb407577d56e4b7444ba61c";
+      sha256 = "sha256-mzMBhnIEgToez6mGFOvO7zBA+rNivZ9OnLQsjBBDamA=";
+    };
+
+    nativeBuildInputs = [pkg-config bison flex];
+    propagatedBuildInputs = [yosys_abc];
+
+    buildInputs = [
+      tcl
+      libedit
+      libbsd
+      libffi
+      zlib
+      py3env
+    ];
+
+    passthru = {
+      inherit py3env;
+      inherit withPlugins;
+    };
+
+    patches = [
+      ./patches/yosys/fix-clang-build.patch
+      ./patches/yosys/plugin-search-dirs.patch
+    ];
+
+    postPatch = ''
+      substituteInPlace ./Makefile \
+        --replace 'echo UNKNOWN' 'echo ${builtins.substring 0 10 src.rev}'
+
+      chmod +x ./misc/yosys-config.in
+      patchShebangs tests ./misc/yosys-config.in
+
+      sed -i 's@ENABLE_EDITLINE := 0@ENABLE_EDITLINE := 1@' Makefile
+      sed -i 's@ENABLE_READLINE := 1@ENABLE_READLINE := 0@' Makefile
+      sed -Ei 's@PRETTY = 1@PRETTY = 0@' ./Makefile
+    '';
+
+    preBuild = let
+      shortAbcRev = builtins.substring 0 7 yosys_abc.rev;
+    in ''
+      chmod -R u+w .
+      make config-clang
+
+      echo 'ABCEXTERNAL = ${yosys_abc}/bin/abc' >> Makefile.conf
+
+      if ! grep -q "ABCREV = ${shortAbcRev}" Makefile; then
+        echo "ERROR: yosys isn't compatible with the provided abc (${yosys_abc}), failing."
+        exit 1
+      fi
+    '';
+
+    postBuild = "ln -sfv ${yosys_abc}/bin/abc ./yosys-abc";
+    postInstall = "ln -sfv ${yosys_abc}/bin/abc $out/bin/yosys-abc";
+
+    makeFlags = ["PREFIX=${placeholder "out"}"];
+    doCheck = false;
+    enableParallelBuilding = true;
+  };
+
+  withPlugins = plugins: let
+    paths = lib.closePropagation plugins;
+    dylibs = lib.lists.flatten (map (n: n.dylibs) plugins);
+  in let
+    module_flags = with builtins;
+      concatStringsSep " "
+      (map (so: "--add-flags -m --add-flags ${so}") dylibs);
+  in (symlinkJoin {
+    name = "${yosys.name}-with-plugins";
+    paths = paths ++ [yosys];
+    nativeBuildInputs = [makeWrapper];
+    postBuild = ''
+      wrapProgram $out/bin/yosys \
+        --set NIX_YOSYS_PLUGIN_DIRS $out/share/yosys/plugins \
+        ${module_flags}
+    '';
+  });
+in
+  yosys


### PR DESCRIPTION
Added Yosys (with Yosys-ABC), included Volare into Nix (an open PDK package manager), rectified a Verilog syntax error introduced by myself; a wire named "do" was used, which is a reserved name, so changed it to "doo." Also, modified the synthesis process to properly handle SDC files and deactivated latch errors if pico32.v is present in the sources. 

Yosys is an open-source framework for Verilog RTL synthesis. It takes Verilog code as input and produces a synthesized netlist as output, which can then be used for further downstream processing, such as placement and routing. Yosys supports a wide range of synthesis optimizations and transformations, allowing users to achieve efficient and optimized hardware designs.

Yosys-ABC is an extension of the Yosys synthesis framework, integrating the ABC (A System for Sequential Synthesis and Verification) tool for logic synthesis. ABC is a highly optimized and widely used academic synthesis tool developed at the University of California, Berkeley.

Volare is a package manager designed specifically for managing Process Design Kits (PDKs) in the context of semiconductor manufacturing and integrated circuit (IC) design. It simplifies the installation and management of PDKs, which contain the necessary technology files, libraries, and models for designing integrated circuits.

The patches are requirements for the specific versions of Yosys-abc and Yosys
