### PR TITLE
fix(CI): update checkout action to use node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: run test
@@ -40,7 +40,7 @@ jobs:
     needs: [ pc-emul ]
   
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: run test
@@ -53,7 +53,7 @@ jobs:
     needs: [ simulation ]
   
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: init mem and no ext mem
@@ -68,7 +68,7 @@ jobs:
     needs: [ simulation ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: init mem and no ext mem
@@ -83,7 +83,7 @@ jobs:
     needs: [ cyclonev ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: run LIB test
@@ -96,7 +96,7 @@ jobs:
     needs: [ lib ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: run uart test
@@ -109,7 +109,7 @@ jobs:
     needs: [ cyclonev ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: run simulation test
@@ -123,7 +123,7 @@ jobs:
     needs: [ cyclonev ]
   
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: 'recursive'
       - name: doc test


### PR DESCRIPTION
- update checkout action to v4 to use node 20 and remove warning:
```
  - Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```