### PR TITLE
Remove macros from some modules

### DIFF
--- a/lib/hardware/modules/fifo/iob_bfifo/hardware/src/iob_bfifo.v
+++ b/lib/hardware/modules/fifo/iob_bfifo/hardware/src/iob_bfifo.v
@@ -1,7 +1,6 @@
 `timescale 1ns / 1ps
 
-`define IOB_CSHIFT_LEFT(DATA_W, DATA, SHIFT) ((DATA << SHIFT) | (DATA >> (DATA_W - SHIFT)))
-`define IOB_CSHIFT_RIGHT(DATA_W, DATA, SHIFT) ((DATA >> SHIFT) | (DATA << (DATA_W - SHIFT)))
+`include "iob_functions.vs"
 
 module iob_bfifo #(
     parameter DATA_W = 21
@@ -56,14 +55,14 @@ module iob_bfifo #(
   assign rdata_o = (rdata[(2*DATA_W)-1-:DATA_W] >> crwidth) << crwidth;
 
   //write mask shifted
-  assign wmask   = `IOB_CSHIFT_RIGHT(BUFFER_SIZE, ({BUFFER_SIZE{1'b1}} >> wwidth_i), wptr);
+  assign wmask   = iob_cshift_right(BUFFER_SIZE, ({BUFFER_SIZE{1'b1}} >> wwidth_i), wptr);
   //read data shifted
-  assign rdata   = `IOB_CSHIFT_LEFT(BUFFER_SIZE, data, rptr);
+  assign rdata   = iob_cshift_left(BUFFER_SIZE, data, rptr);
 
   always @* begin
     //write data shifted
     wdata_int = (wdata_i >> cwwidth) << cwwidth;
-    wdata     = `IOB_CSHIFT_RIGHT(BUFFER_SIZE, {wdata_int, {DATA_W{1'b0}}}, wptr);
+    wdata     = iob_cshift_right(BUFFER_SIZE, {wdata_int, {DATA_W{1'b0}}}, wptr);
     data_nxt  = data;
     rptr_nxt  = rptr;
     wptr_nxt  = wptr;

--- a/lib/hardware/modules/fifo/iob_bfifo/iob_bfifo.py
+++ b/lib/hardware/modules/fifo/iob_bfifo/iob_bfifo.py
@@ -9,6 +9,11 @@ def setup(py_params_dict):
                 "core_name": "iob_reg_r",
                 "instance_name": "iob_reg_r_inst",
             },
+            # For simulation
+            {
+                "core_name": "iob_functions",
+                "instance_name": "iob_functions_inst",
+            },
         ],
     }
 

--- a/lib/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
+++ b/lib/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
@@ -1,6 +1,6 @@
 `timescale 1ns / 1ps
 
-`define IOB_PULSE(VAR, PRE, DURATION, POST) VAR=0; #PRE VAR=1; #DURATION VAR=0; #POST;
+//`define IOB_PULSE(VAR, PRE, DURATION, POST) VAR=0; #PRE VAR=1; #DURATION VAR=0; #POST;
 
 // TODO: re-implement these tests
 //      $(VLOG) -DW_DATA_W=8 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
@@ -108,7 +108,7 @@ module iob_fifo_async_tb;
     $dumpvars();
 `endif
 
-    #10 `IOB_PULSE(arst, 50, 50, 50)
+    #10; //`IOB_PULSE(arst, 50, 50, 50) // FIXME: Replaced by iob_pulse below but simulation hangs
 
     //fill up the FIFO
     @(posedge w_clk) #1;
@@ -137,6 +137,14 @@ module iob_fifo_async_tb;
       w_en = 0;
     end
   end
+
+  iob_pulse #(
+      .PRE(50),
+      .DURATION(50),
+      .POST(50)
+  ) iob_pulse_1 (
+      .pulse_o(w_arst)
+  );
 
   //
   // READ PROCESS

--- a/lib/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
+++ b/lib/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
@@ -143,7 +143,7 @@ module iob_fifo_async_tb;
       .DURATION(50),
       .POST(50)
   ) iob_pulse_1 (
-      .pulse_o(w_arst)
+      .pulse_o(arst)
   );
 
   //

--- a/lib/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
+++ b/lib/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
@@ -1,7 +1,5 @@
 `timescale 1ns / 1ps
 
-`include "iob_functions.vs"
-
 `define IOB_PULSE(VAR, PRE, DURATION, POST) VAR=0; #PRE VAR=1; #DURATION VAR=0; #POST;
 
 // TODO: re-implement these tests

--- a/lib/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
+++ b/lib/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
@@ -30,7 +30,7 @@ module iob_fifo_async_tb;
 
 
   //global reset
-  reg arst = 0;
+  wire arst = 0;
 
   //write reset
   reg w_arst = 0;

--- a/lib/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
+++ b/lib/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
@@ -1,11 +1,10 @@
 `timescale 1ns / 1ps
 
-`define IOB_MAX(a, b) (((a) > (b)) ? (a) : (b))
-`define IOB_MIN(a, b) (((a) < (b)) ? (a) : (b))
-`define IOB_CLOCK(CLK, PER) initial CLK=0; always #(PER/2) CLK = ~CLK;
+`include "iob_functions.vs"
+
 `define IOB_PULSE(VAR, PRE, DURATION, POST) VAR=0; #PRE VAR=1; #DURATION VAR=0; #POST;
 
-// TODO: re-implement these tests 
+// TODO: re-implement these tests
 //      $(VLOG) -DW_DATA_W=8 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
 //      $(VLOG) -DW_DATA_W=32 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
 //      $(VLOG) -DW_DATA_W=8 -DR_DATA_W=32 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
@@ -23,8 +22,8 @@ module iob_fifo_async_tb;
   localparam TESTSIZE = `TESTSIZE;  //bytes
   localparam W_DATA_W = 8;
   localparam R_DATA_W = 8;
-  localparam MAXDATA_W = `IOB_MAX(W_DATA_W, R_DATA_W);
-  localparam MINDATA_W = `IOB_MIN(W_DATA_W, R_DATA_W);
+  localparam MAXDATA_W = iob_max(W_DATA_W, R_DATA_W);
+  localparam MINDATA_W = iob_min(W_DATA_W, R_DATA_W);
   localparam ADDR_W = `ADDR_W;
   localparam R = MAXDATA_W / MINDATA_W;
   localparam MINADDR_W = ADDR_W - $clog2(R);  //lower ADDR_W (higher DATA_W)
@@ -35,13 +34,13 @@ module iob_fifo_async_tb;
   //global reset
   reg arst = 0;
 
-  //write reset 
+  //write reset
   reg w_arst = 0;
   always @(posedge w_clk, posedge arst)
     if (arst) w_arst = 1;
     else w_arst = #1 arst;
 
-  //read reset 
+  //read reset
   reg r_arst = 0;
   always @(posedge r_clk, posedge arst)
     if (arst) r_arst = 1;
@@ -49,11 +48,19 @@ module iob_fifo_async_tb;
 
   //write clock
   reg w_clk;
-  `IOB_CLOCK(w_clk, 10)
+  iob_clock #(
+     .CLK_PERIOD(10)
+  ) iob_clock_1 (
+     .clk_o(w_clk)
+  );
 
   //read clock
   reg r_clk;
-  `IOB_CLOCK(r_clk, 13)
+  iob_clock #(
+     .CLK_PERIOD(13)
+  ) iob_clock_2 (
+     .clk_o(r_clk)
+  );
 
   reg                 r_cke = 1;
   reg                 w_cke = 1;

--- a/lib/hardware/modules/fifo/iob_fifo_async/hardware/src/iob_fifo_async.v
+++ b/lib/hardware/modules/fifo/iob_fifo_async/hardware/src/iob_fifo_async.v
@@ -1,7 +1,5 @@
 `timescale 1ns / 1ps
 
-`include "iob_functions.vs"
-
 module iob_fifo_async #(
     parameter W_DATA_W = 21,
     parameter R_DATA_W = 21,

--- a/lib/hardware/modules/fifo/iob_fifo_async/hardware/src/iob_fifo_async.v
+++ b/lib/hardware/modules/fifo/iob_fifo_async/hardware/src/iob_fifo_async.v
@@ -1,16 +1,14 @@
 `timescale 1ns / 1ps
 
-`define IOB_MAX(a, b) (((a) > (b)) ? (a) : (b))
-`define IOB_MIN(a, b) (((a) < (b)) ? (a) : (b))
-
+`include "iob_functions.vs"
 
 module iob_fifo_async #(
     parameter W_DATA_W = 21,
     parameter R_DATA_W = 21,
     parameter ADDR_W = 3,  //higher ADDR_W lower DATA_W
     //determine W_ADDR_W and R_ADDR_W
-    parameter MAXDATA_W = `IOB_MAX(W_DATA_W, R_DATA_W),
-    parameter MINDATA_W = `IOB_MIN(W_DATA_W, R_DATA_W),
+    parameter MAXDATA_W = iob_max(W_DATA_W, R_DATA_W),
+    parameter MINDATA_W = iob_min(W_DATA_W, R_DATA_W),
     parameter R = MAXDATA_W / MINDATA_W,
     parameter ADDR_W_DIFF = $clog2(R),
     parameter MINADDR_W = ADDR_W - $clog2(R),  //lower ADDR_W (higher DATA_W)

--- a/lib/hardware/modules/fifo/iob_fifo_async/iob_fifo_async.py
+++ b/lib/hardware/modules/fifo/iob_fifo_async/iob_fifo_async.py
@@ -213,6 +213,14 @@ def setup(py_params_dict):
                 "core_name": "iob_ram_t2p",
                 "instance_name": "iob_ram_t2p_inst",
             },
+            {
+                "core_name": "iob_clock",
+                "instance_name": "iob_clock_inst",
+            },
+            {
+                "core_name": "iob_functions",
+                "instance_name": "iob_functions_inst",
+            },
         ],
     }
 

--- a/lib/hardware/modules/fifo/iob_fifo_async/iob_fifo_async.py
+++ b/lib/hardware/modules/fifo/iob_fifo_async/iob_fifo_async.py
@@ -208,10 +208,11 @@ def setup(py_params_dict):
                 "core_name": "iob_asym_converter",
                 "instance_name": "iob_asym_converter_inst",
             },
-            {
-                "core_name": "iob_functions",
-                "instance_name": "iob_functions_inst",
-            },
+            # Already included with iob_asym_converter
+            # {
+            #    "core_name": "iob_functions",
+            #    "instance_name": "iob_functions_inst",
+            # },
             # For simulation
             {
                 "core_name": "iob_ram_t2p",

--- a/lib/hardware/modules/fifo/iob_fifo_async/iob_fifo_async.py
+++ b/lib/hardware/modules/fifo/iob_fifo_async/iob_fifo_async.py
@@ -222,6 +222,10 @@ def setup(py_params_dict):
                 "core_name": "iob_clock",
                 "instance_name": "iob_clock_inst",
             },
+            {
+                "core_name": "iob_pulse",
+                "instance_name": "iob_pulse_inst",
+            },
         ],
     }
 

--- a/lib/hardware/modules/fifo/iob_fifo_async/iob_fifo_async.py
+++ b/lib/hardware/modules/fifo/iob_fifo_async/iob_fifo_async.py
@@ -208,6 +208,10 @@ def setup(py_params_dict):
                 "core_name": "iob_asym_converter",
                 "instance_name": "iob_asym_converter_inst",
             },
+            {
+                "core_name": "iob_functions",
+                "instance_name": "iob_functions_inst",
+            },
             # For simulation
             {
                 "core_name": "iob_ram_t2p",
@@ -216,10 +220,6 @@ def setup(py_params_dict):
             {
                 "core_name": "iob_clock",
                 "instance_name": "iob_clock_inst",
-            },
-            {
-                "core_name": "iob_functions",
-                "instance_name": "iob_functions_inst",
             },
         ],
     }

--- a/lib/hardware/modules/fifo/iob_fifo_sync/hardware/simulation/src/iob_fifo_sync_tb.v
+++ b/lib/hardware/modules/fifo/iob_fifo_sync/hardware/simulation/src/iob_fifo_sync_tb.v
@@ -1,21 +1,18 @@
 `timescale 1ns / 1ps
 
-/* TODO: re-implement these tests 
+/* TODO: re-implement these tests
 -       $(VLOG) -DW_DATA_W=8 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)*.v) &&\
 -       $(VLOG) -DW_DATA_W=32 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)*.v) &&\
 -       $(VLOG) -DW_DATA_W=8 -DR_DATA_W=32 $(wildcard $(BUILD_VSRC_DIR)*.v) &&\
 -       $(VLOG) -DW_DATA_W=8 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)*.v) &&\
 */
 
-`define IOB_MAX(a, b) (((a) > (b)) ? (a) : (b))
-`define IOB_MIN(a, b) (((a) < (b)) ? (a) : (b))
-
 module iob_fifo_sync_tb;
 
   localparam W_DATA_W = 8;
   localparam R_DATA_W = 8;
-  localparam MAXDATA_W = `IOB_MAX(W_DATA_W, R_DATA_W);
-  localparam MINDATA_W = `IOB_MIN(W_DATA_W, R_DATA_W);
+  localparam MAXDATA_W = iob_max(W_DATA_W, R_DATA_W);
+  localparam MINDATA_W = iob_min(W_DATA_W, R_DATA_W);
   localparam ADDR_W = 10;
   localparam R = MAXDATA_W / MINDATA_W;
   localparam MINADDR_W = ADDR_W - $clog2(R);  //lower ADDR_W (higher DATA_W)

--- a/lib/hardware/modules/fifo/iob_fifo_sync/hardware/src/iob_fifo_sync.v
+++ b/lib/hardware/modules/fifo/iob_fifo_sync/hardware/src/iob_fifo_sync.v
@@ -1,15 +1,14 @@
 `timescale 1ns / 1ps
 
-`define IOB_MAX(a, b) (((a) > (b)) ? (a) : (b))
-`define IOB_MIN(a, b) (((a) < (b)) ? (a) : (b))
+`include "iob_functions.vs"
 
 module iob_fifo_sync #(
     parameter W_DATA_W = 21,
     R_DATA_W = 21,
     ADDR_W = 21,  //higher ADDR_W lower DATA_W
     //determine W_ADDR_W and R_ADDR_W
-    MAXDATA_W = `IOB_MAX(W_DATA_W, R_DATA_W),
-    MINDATA_W = `IOB_MIN(W_DATA_W, R_DATA_W),
+    MAXDATA_W = iob_max(W_DATA_W, R_DATA_W),
+    MINDATA_W = iob_min(W_DATA_W, R_DATA_W),
     R = MAXDATA_W / MINDATA_W,
     MINADDR_W = ADDR_W - $clog2(R),  //lower ADDR_W (higher DATA_W)
     W_ADDR_W = (W_DATA_W == MAXDATA_W) ? MINADDR_W : ADDR_W,

--- a/lib/hardware/modules/fifo/iob_fifo_sync/hardware/src/iob_fifo_sync.v
+++ b/lib/hardware/modules/fifo/iob_fifo_sync/hardware/src/iob_fifo_sync.v
@@ -1,7 +1,5 @@
 `timescale 1ns / 1ps
 
-`include "iob_functions.vs"
-
 module iob_fifo_sync #(
     parameter W_DATA_W = 21,
     R_DATA_W = 21,

--- a/lib/hardware/modules/fifo/iob_fifo_sync/iob_fifo_sync.py
+++ b/lib/hardware/modules/fifo/iob_fifo_sync/iob_fifo_sync.py
@@ -166,10 +166,11 @@ def setup(py_params_dict):
                 "core_name": "iob_ram_2p",
                 "instance_name": "iob_ram_2p_inst",
             },
-            {
-                "core_name": "iob_functions",
-                "instance_name": "iob_functions_inst",
-            },
+            # Already included in iob_asym_converter
+            # {
+            #     "core_name": "iob_functions",
+            #     "instance_name": "iob_functions_inst",
+            # },
         ],
     }
 

--- a/lib/hardware/modules/fifo/iob_fifo_sync/iob_fifo_sync.py
+++ b/lib/hardware/modules/fifo/iob_fifo_sync/iob_fifo_sync.py
@@ -166,6 +166,10 @@ def setup(py_params_dict):
                 "core_name": "iob_ram_2p",
                 "instance_name": "iob_ram_2p_inst",
             },
+            {
+                "core_name": "iob_functions",
+                "instance_name": "iob_functions_inst",
+            },
         ],
     }
 

--- a/lib/hardware/modules/iob2axi/hardware/src/iob2axi.v
+++ b/lib/hardware/modules/iob2axi/hardware/src/iob2axi.v
@@ -1,7 +1,6 @@
 `timescale 1ns / 1ps
 
-`define IOB_MIN(a, b) (((a) < (b)) ? (a) : (b))
-
+`include "iob_functions.vs"
 
 module iob2axi #(
     parameter ADDR_W     = 0,
@@ -218,7 +217,7 @@ module iob2axi #(
   reg [WADDR_W-1:0] addr_int_next;
   wire [WADDR_W-1:0] addr4k = {addr_int[ADDR_W-1:12], {(12 - (ADDR_W - WADDR_W)) {1'b1}}};
   wire [WADDR_W-1:0] addrRem = addr_int[ADDR_W-1-:WADDR_W] + length_int - 1'b1;
-  wire [WADDR_W-1:0] minAddr = `IOB_MIN(addr4k, addrRem);
+  wire [WADDR_W-1:0] minAddr = iob_min(addr4k, addrRem);
 
   always @(posedge clk_i, posedge rst_i) begin
     if (rst_i) begin

--- a/lib/hardware/modules/iob2axi/iob2axi.py
+++ b/lib/hardware/modules/iob2axi/iob2axi.py
@@ -37,6 +37,10 @@ def setup(py_params_dict):
                 "core_name": "iob_fifo_sync",
                 "instance_name": "iob_fifo_sync_inst",
             },
+            {
+                "core_name": "iob_functions",
+                "instance_name": "iob_functions_inst",
+            },
         ],
     }
 

--- a/lib/hardware/modules/iob_asym_converter/hardware/src/iob_asym_converter.v
+++ b/lib/hardware/modules/iob_asym_converter/hardware/src/iob_asym_converter.v
@@ -1,15 +1,14 @@
 `timescale 1ns / 1ps
 
-`define IOB_MAX(a, b) (((a) > (b)) ? (a) : (b))
-`define IOB_MIN(a, b) (((a) < (b)) ? (a) : (b))
+`include "iob_functions.vs"
 
 module iob_asym_converter #(
     parameter W_DATA_W = 21,
     parameter R_DATA_W = 21,
     parameter ADDR_W = 3,  //higher ADDR_W lower DATA_W
     //determine W_ADDR_W and R_ADDR_W
-    parameter MAXDATA_W = `IOB_MAX(W_DATA_W, R_DATA_W),
-    parameter MINDATA_W = `IOB_MIN(W_DATA_W, R_DATA_W),
+    parameter MAXDATA_W = iob_max(W_DATA_W, R_DATA_W),
+    parameter MINDATA_W = iob_min(W_DATA_W, R_DATA_W),
     parameter R = MAXDATA_W / MINDATA_W,
     parameter MINADDR_W = ADDR_W - $clog2(R),  //lower ADDR_W (higher DATA_W)
     parameter W_ADDR_W = (W_DATA_W == MAXDATA_W) ? MINADDR_W : ADDR_W,

--- a/lib/hardware/modules/iob_asym_converter/iob_asym_converter.py
+++ b/lib/hardware/modules/iob_asym_converter/iob_asym_converter.py
@@ -139,6 +139,10 @@ def setup(py_params_dict):
                 "core_name": "iob_reg_re",
                 "instance_name": "iob_reg_re_inst",
             },
+            {
+                "core_name": "iob_functions",
+                "instance_name": "iob_functions_inst",
+            },
         ],
     }
 

--- a/lib/hardware/modules/iob_clock/iob_clock.py
+++ b/lib/hardware/modules/iob_clock/iob_clock.py
@@ -1,0 +1,38 @@
+def setup(py_params_dict):
+    attributes_dict = {
+        "original_name": "iob_clock",
+        "name": "iob_clock",
+        "version": "0.1",
+        "confs": [
+            {
+                "name": "CLK_PERIOD",
+                "type": "P",
+                "val": "10",
+                "min": "",
+                "max": "",
+                "descr": "Clock period",
+            },
+        ],
+        "ports": [
+            {
+                "name": "clk",
+                "descr": "Output clock",
+                "signals": [
+                    {"name": "clk", "width": "1", "direction": "output"},
+                ],
+            },
+        ],
+        "snippets": [
+            {
+                "outputs": ["clk_o"],
+                "verilog_code": """
+   reg clk;
+   assign clk_o = clk;
+
+   initial clk = 0; always #(CLK_PERIOD/2) clk = ~clk;
+        """,
+            }
+        ],
+    }
+
+    return attributes_dict

--- a/lib/hardware/modules/iob_clock/iob_clock.py
+++ b/lib/hardware/modules/iob_clock/iob_clock.py
@@ -24,7 +24,7 @@ def setup(py_params_dict):
         ],
         "snippets": [
             {
-                "outputs": ["clk_o"],
+                "outputs": ["clk"],
                 "verilog_code": """
    reg clk;
    assign clk_o = clk;

--- a/lib/hardware/modules/iob_functions/hardware/src/iob_functions.vs
+++ b/lib/hardware/modules/iob_functions/hardware/src/iob_functions.vs
@@ -15,3 +15,21 @@ function [31:0] iob_min;
       else iob_min = b;
    end
 endfunction
+
+function [31:0] iob_cshift_left;
+   input [31:0] DATA;
+   input integer DATA_W;
+   input integer SHIFT;
+   begin
+      iob_cshift_left = (DATA << SHIFT) | (DATA >> (DATA_W - SHIFT));
+   end
+endfunction
+
+function [31:0] iob_cshift_right;
+   input [31:0] DATA;
+   input integer DATA_W;
+   input integer SHIFT;
+   begin
+      iob_cshift_right = (DATA >> SHIFT) | (DATA << (DATA_W - SHIFT));
+   end
+endfunction

--- a/lib/hardware/modules/iob_functions/hardware/src/iob_functions.vs
+++ b/lib/hardware/modules/iob_functions/hardware/src/iob_functions.vs
@@ -1,0 +1,17 @@
+function [31:0] iob_max;
+   input [31:0] a;
+   input [31:0] b;
+   begin
+      if (a > b) iob_max = a;
+      else iob_max = b;
+   end
+endfunction
+
+function [31:0] iob_min;
+   input [31:0] a;
+   input [31:0] b;
+   begin
+      if (a < b) iob_min = a;
+      else iob_min = b;
+   end
+endfunction

--- a/lib/hardware/modules/iob_functions/iob_functions.py
+++ b/lib/hardware/modules/iob_functions/iob_functions.py
@@ -1,0 +1,9 @@
+def setup(py_params_dict):
+    attributes_dict = {
+        "original_name": "iob_functions",
+        "name": "iob_functions",
+        "version": "0.1",
+        "generate_hw": False,
+    }
+
+    return attributes_dict

--- a/lib/hardware/modules/iob_nco/hardware/simulation/src/iob_nco_tb.v
+++ b/lib/hardware/modules/iob_nco/hardware/simulation/src/iob_nco_tb.v
@@ -3,10 +3,10 @@
 
 `include "iob_functions.vs"
 
-`define IOB_RESET(CLK, RESET, PRE, DURATION, POST) RESET=~`IOB_REG_RST_POL;\
-   #PRE RESET=`IOB_REG_RST_POL; #DURATION RESET=~`IOB_REG_RST_POL; #POST;\
-   @(posedge CLK) #1;
-`define IOB_PULSE(VAR, PRE, DURATION, POST) VAR=0; #PRE VAR=1; #DURATION VAR=0; #POST;
+//`define IOB_RESET(CLK, RESET, PRE, DURATION, POST) RESET=~`IOB_REG_RST_POL;\
+//   #PRE RESET=`IOB_REG_RST_POL; #DURATION RESET=~`IOB_REG_RST_POL; #POST;\
+//   @(posedge CLK) #1;
+//`define IOB_PULSE(VAR, PRE, DURATION, POST) VAR=0; #PRE VAR=1; #DURATION VAR=0; #POST;
 
 module iob_nco_tb;
 
@@ -34,9 +34,11 @@ module iob_nco_tb;
     $dumpvars();
 `endif
 
-    `IOB_RESET(clk, arst, 23, 23, 23)
+    // TODO: Replaced by iob_reset below. Confirm if it's well done
+    //`IOB_RESET(clk, arst, 23, 23, 23)
 
-    `IOB_PULSE(ld, 23, 20, 20)
+    // TODO: Replaced by iob_reset below. Confirm if it's well done
+    //`IOB_PULSE(ld, 23, 20, 20)
 
     $display("%c[1;34m", 27);
     $display("Test completed successfully.");
@@ -47,6 +49,23 @@ module iob_nco_tb;
     #1000 $finish();
 
   end
+
+  iob_pulse #(
+      .PRE(23),
+      .DURATION(20),
+      .POST(20)
+  ) pulse (
+      .pulse_o(ld)
+  );
+
+  iob_reset #(
+      .PRE(23),
+      .DURATION(23),
+      .POST(23)
+  ) reset (
+      .clk_i(clk),
+      .reset_o(arst)
+  );
 
   iob_nco #(
       .DATA_W(16),

--- a/lib/hardware/modules/iob_nco/hardware/simulation/src/iob_nco_tb.v
+++ b/lib/hardware/modules/iob_nco/hardware/simulation/src/iob_nco_tb.v
@@ -1,7 +1,8 @@
 `timescale 1ns / 1ps
 `include "iob_reg_conf.vh"
 
-`define IOB_CLOCK(CLK, PER) initial CLK=0; always #(PER/2) CLK = ~CLK;
+`include "iob_functions.vs"
+
 `define IOB_RESET(CLK, RESET, PRE, DURATION, POST) RESET=~`IOB_REG_RST_POL;\
    #PRE RESET=`IOB_REG_RST_POL; #DURATION RESET=~`IOB_REG_RST_POL; #POST;\
    @(posedge CLK) #1;
@@ -14,7 +15,11 @@ module iob_nco_tb;
   localparam CLK_PER = 10;
 
   reg clk;
-  `IOB_CLOCK(clk, CLK_PER)
+  iob_clock #(
+     .CLK_PERIOD(CLK_PER)
+  ) iob_clock_1 (
+     .clk_o(clk)
+  );
   reg  cke = 1'b1;
   reg  arst;
 

--- a/lib/hardware/modules/iob_nco/iob_nco.py
+++ b/lib/hardware/modules/iob_nco/iob_nco.py
@@ -21,6 +21,15 @@ def setup(py_params_dict):
                 "core_name": "iob_acc_ld",
                 "instance_name": "iob_acc_ld_inst",
             },
+            {
+                "core_name": "iob_functions",
+                "instance_name": "iob_functions_inst",
+            },
+            # For simulation
+            {
+                "core_name": "iob_clock",
+                "instance_name": "iob_clock_inst",
+            },
         ],
     }
 

--- a/lib/hardware/modules/iob_nco/iob_nco.py
+++ b/lib/hardware/modules/iob_nco/iob_nco.py
@@ -30,6 +30,14 @@ def setup(py_params_dict):
                 "core_name": "iob_clock",
                 "instance_name": "iob_clock_inst",
             },
+            {
+                "core_name": "iob_pulse",
+                "instance_name": "iob_pulse_inst",
+            },
+            {
+                "core_name": "iob_reset",
+                "instance_name": "iob_reset_inst",
+            },
         ],
     }
 

--- a/lib/hardware/modules/iob_pulse/iob_pulse.py
+++ b/lib/hardware/modules/iob_pulse/iob_pulse.py
@@ -1,0 +1,59 @@
+def setup(py_params_dict):
+    attributes_dict = {
+        "original_name": "iob_pulse",
+        "name": "iob_pulse",
+        "version": "0.1",
+        "confs": [
+            {
+                "name": "PRE",
+                "type": "P",
+                "val": "1",
+                "min": "",
+                "max": "",
+                "descr": "Clock period",
+            },
+            {
+                "name": "DURATION",
+                "type": "P",
+                "val": "0",
+                "min": "",
+                "max": "",
+                "descr": "",
+            },
+            {
+                "name": "POST",
+                "type": "P",
+                "val": "0",
+                "min": "",
+                "max": "",
+                "descr": "",
+            },
+        ],
+        "ports": [
+            {
+                "name": "pulse",
+                "descr": "Output pulse",
+                "signals": [
+                    {"name": "pulse", "width": "1", "direction": "output"},
+                ],
+            },
+        ],
+        "snippets": [
+            {
+                "outputs": ["pulse"],
+                "verilog_code": """
+   reg pulse;
+   assign pulse_o = pulse;
+
+   initial begin
+      pulse=0;
+      #PRE pulse=1;
+      #DURATION pulse=0;
+      #POST;
+   end
+                """,
+            }
+        ],
+    }
+
+    return attributes_dict

--- a/lib/hardware/modules/iob_reset/iob_reset.py
+++ b/lib/hardware/modules/iob_reset/iob_reset.py
@@ -1,0 +1,67 @@
+def setup(py_params_dict):
+    attributes_dict = {
+        "original_name": "iob_reset",
+        "name": "iob_reset",
+        "version": "0.1",
+        "confs": [
+            {
+                "name": "PRE",
+                "type": "P",
+                "val": "1",
+                "min": "",
+                "max": "",
+                "descr": "Clock period",
+            },
+            {
+                "name": "DURATION",
+                "type": "P",
+                "val": "0",
+                "min": "",
+                "max": "",
+                "descr": "",
+            },
+            {
+                "name": "POST",
+                "type": "P",
+                "val": "0",
+                "min": "",
+                "max": "",
+                "descr": "",
+            },
+        ],
+        "ports": [
+            {
+                "name": "clk",
+                "descr": "Input clock",
+                "signals": [
+                    {"name": "clk", "width": "1", "direction": "input"},
+                ],
+            },
+            {
+                "name": "reset",
+                "descr": "Output reset",
+                "signals": [
+                    {"name": "pulse", "width": "1", "direction": "output"},
+                ],
+            },
+        ],
+        "snippets": [
+            {
+                "outputs": ["reset"],
+                "verilog_code": """
+   reg reset;
+   assign reset_o = reset;
+
+   initial begin
+      reset = ~`IOB_REG_RST_POL;
+      #PRE reset = `IOB_REG_RST_POL;
+      #DURATION reset = ~`IOB_REG_RST_POL;
+      #POST;
+      @(posedge clk_i) #1;
+   end
+                """,
+            }
+        ],
+    }
+
+    return attributes_dict

--- a/lib/hardware/modules/iob_reset/iob_reset.py
+++ b/lib/hardware/modules/iob_reset/iob_reset.py
@@ -41,7 +41,7 @@ def setup(py_params_dict):
                 "name": "reset",
                 "descr": "Output reset",
                 "signals": [
-                    {"name": "pulse", "width": "1", "direction": "output"},
+                    {"name": "reset", "width": "1", "direction": "output"},
                 ],
             },
         ],

--- a/lib/hardware/modules/iob_uart/hardware/simulation/src/iob_uart_tb.v
+++ b/lib/hardware/modules/iob_uart/hardware/simulation/src/iob_uart_tb.v
@@ -26,7 +26,7 @@ module iob_uart_tb;
   integer i, fd;
 
   // CORE SIGNALS
-  reg                        arst = ~`IOB_REG_RST_POL;
+  wire                       arst;
   reg                        clk;
 
   //control interface (backend)

--- a/lib/hardware/modules/iob_uart/hardware/simulation/src/iob_uart_tb.v
+++ b/lib/hardware/modules/iob_uart/hardware/simulation/src/iob_uart_tb.v
@@ -3,9 +3,9 @@
 `include "iob_uart_swreg_def.vh"
 `include "iob_reg_conf.vh"
 
-`define IOB_RESET(CLK, RESET, PRE, DURATION, POST) RESET=~`IOB_REG_RST_POL;\
-   #PRE RESET=`IOB_REG_RST_POL; #DURATION RESET=~`IOB_REG_RST_POL; #POST;\
-   @(posedge CLK) #1;
+//`define IOB_RESET(CLK, RESET, PRE, DURATION, POST) RESET=~`IOB_REG_RST_POL;\
+//   #PRE RESET=`IOB_REG_RST_POL; #DURATION RESET=~`IOB_REG_RST_POL; #POST;\
+//   @(posedge CLK) #1;
 
 //ASCII codes used
 `define STX 2 //start of text
@@ -49,6 +49,15 @@ module iob_uart_tb;
   wire                       tx2rx;
 
 
+  iob_reset #(
+     .PRE      (100),
+     .DURATION (1_000),
+     .POST     (100)
+  ) iob_reset_1 (
+     .clk_i   (clk),
+     .reset_o (arst)
+  );
+
   initial begin
 `ifdef VCD
     $dumpfile("uut.vcd");
@@ -67,7 +76,8 @@ module iob_uart_tb;
     div      = clk_frequency / baud_rate;
 
     //apply async reset
-    `IOB_RESET(clk, arst, 100, 1_000, 100);
+    // TODO: Replace by iob_reset above. Confirm if it's well done
+    //`IOB_RESET(clk, arst, 100, 1_000, 100);
 
     // assert tx not ready
     if (tx_ready) begin
@@ -97,7 +107,7 @@ module iob_uart_tb;
     // write data to send
     for (i = 0; i < 256; i = i + 1) begin
 
-      //wait for tx ready 
+      //wait for tx ready
       do @(posedge clk); while (!tx_ready);
 
       //write word to send
@@ -105,7 +115,7 @@ module iob_uart_tb;
       tx_data = i;
       @(posedge clk) #1 wr_en = 0;
 
-      //wait for core to receive datarx ready 
+      //wait for core to receive datarx ready
       do @(posedge clk); while (!rx_ready);
 
       //read received word

--- a/lib/hardware/modules/iob_uart/iob_uart.py
+++ b/lib/hardware/modules/iob_uart/iob_uart.py
@@ -209,6 +209,10 @@ def setup(py_params_dict):
                 "core_name": "iob_reg_e",
                 "instance_name": "iob_reg_e_inst",
             },
+            {
+                "core_name": "iob_reset",
+                "instance_name": "iob_reset_inst",
+            },
         ],
     }
 


### PR DESCRIPTION
I couldn't remove all macros though. IOB_PULSE and IOB_RESET hang the simulation when I replace with an equivalent task. Haven't figured out yet how to fix that. The other macros were removed and replaced by functions in the new iob_functions module or by the new iob_clock module.