### PR TITLE
Use new `py_params` argument separator `:`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ INIT_MEM ?= 1
 USE_EXTMEM ?= 0
 
 setup:
-	$(call IOB_NIX_ENV, py2hwsw $(CORE) setup --no_verilog_lint --py_params "init_mem=$(INIT_MEM);use_extmem=$(USE_EXTMEM)")
+	$(call IOB_NIX_ENV, py2hwsw $(CORE) setup --no_verilog_lint --py_params 'init_mem=$(INIT_MEM):use_extmem=$(USE_EXTMEM)')
 
 pc-emul-run:
 	$(call IOB_NIX_ENV, make clean setup && make -C ../$(CORE)_V*/ pc-emul-run)

--- a/lib/scripts/default.nix
+++ b/lib/scripts/default.nix
@@ -1,7 +1,7 @@
 { pkgs ? import <nixpkgs> {} }:
 
 let
-  py2hwsw_commit = "c1122bc435e16422f4f04fa973882cc3eb3979cc"; # Replace with the desired commit.
+  py2hwsw_commit = "f24f15cfa8b21f660b24a15af57423d0c501e041"; # Replace with the desired commit.
 
   py2hwsw = pkgs.python3.pkgs.buildPythonPackage rec {
     pname = "py2hwsw";
@@ -11,7 +11,7 @@ let
       owner = "IObundle";
       repo = "py2hwsw";
       rev = py2hwsw_commit;
-      sha256 = "wD4GRc/E8+NPZDZC1su8l7agV/zmaaehorhcmq6Jyhs=";  # Replace with the actual SHA256 hash.
+      sha256 = "72SBftfmGKldDt7cFNz4aIB2hFytWtO6tivJKMaTlNA=";  # Replace with the actual SHA256 hash.
     };
 
     # Add any necessary dependencies here.


### PR DESCRIPTION
The new `:` separator correctly captures the value for `use_extmem` passed from Makefile.
See description of https://github.com/arturum1/py2hwsw/commit/f24f15cfa8b21f660b24a15af57423d0c501e041 for details.