### PR TITLE
Use Nix import instead of symlink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
 
   lib:
     runs-on: self-hosted
-    timeout-minutes: 5
+    timeout-minutes: 10
     if: ${{ !cancelled() }}
     needs: [ cyclonev ]
 

--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,2 @@
-submodules/LIB/scripts/default.nix
+{ pkgs ? import <nixpkgs> {} }:
+import submodules/LIB/scripts/default.nix { inherit pkgs; }

--- a/submodules/LIB/default.nix
+++ b/submodules/LIB/default.nix
@@ -1,1 +1,2 @@
-scripts/default.nix
+{ pkgs ? import <nixpkgs> {} }:
+import scripts/default.nix { inherit pkgs; }

--- a/submodules/LIB/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
+++ b/submodules/LIB/hardware/modules/fifo/iob_fifo_async/hardware/simulation/src/iob_fifo_async_tb.v
@@ -2,12 +2,12 @@
 
 `include "iob_utils.vh"
 
-/* TODO: re-implement these tests 
--       $(VLOG) -DW_DATA_W=8 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
--       $(VLOG) -DW_DATA_W=32 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
--       $(VLOG) -DW_DATA_W=8 -DR_DATA_W=32 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
--       $(VLOG) -DW_DATA_W=8 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
-*/
+// TODO: re-implement these tests 
+//      $(VLOG) -DW_DATA_W=8 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
+//      $(VLOG) -DW_DATA_W=32 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
+//      $(VLOG) -DW_DATA_W=8 -DR_DATA_W=32 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
+//      $(VLOG) -DW_DATA_W=8 -DR_DATA_W=8 $(wildcard $(BUILD_VSRC_DIR)/*.v) &&\
+//
 
 
 //test defines
@@ -20,10 +20,8 @@ module iob_fifo_async_tb;
    localparam TESTSIZE = `TESTSIZE;  //bytes
    localparam W_DATA_W = 8;
    localparam R_DATA_W = 8;
-   localparam MAXDATA_W =
-   `IOB_MAX(W_DATA_W, R_DATA_W);
-   localparam MINDATA_W =
-   `IOB_MIN(W_DATA_W, R_DATA_W);
+   localparam MAXDATA_W = `IOB_MAX(W_DATA_W, R_DATA_W);
+   localparam MINDATA_W = `IOB_MIN(W_DATA_W, R_DATA_W);
    localparam ADDR_W = `ADDR_W;
    localparam R = MAXDATA_W / MINDATA_W;
    localparam MINADDR_W = ADDR_W - $clog2(R);  //lower ADDR_W (higher DATA_W)
@@ -73,10 +71,10 @@ module iob_fifo_async_tb;
    wire [    ADDR_W:0] r_level;
 
    integer i, j;  //iterators
-   integer fd;
+   integer                  fd;
 
-   reg [TESTSIZE*8-1:0] test_data;
-   reg [TESTSIZE*8-1:0] read;
+   reg     [TESTSIZE*8-1:0] test_data;
+   reg     [TESTSIZE*8-1:0] read;
 
    //
    // WRITE PROCESS

--- a/submodules/LIB/hardware/modules/iob_inv/hardware/src/iob_inv.v
+++ b/submodules/LIB/hardware/modules/iob_inv/hardware/src/iob_inv.v
@@ -1,15 +1,12 @@
 `timescale 1ns / 1ps
 
 
-module iob_inv
-  #(
-    parameter W = 21
+module iob_inv #(
+   parameter W = 21
 ) (
-   input [W-1:0] in_i,
-   output [W-1:0]  out_o
+   input  [W-1:0] in_i,
+   output [W-1:0] out_o
 );
-
-   wire [W-1:0]  out_o;
 
    assign out_o = ~in_i;
 

--- a/submodules/LIB/scripts/default.nix
+++ b/submodules/LIB/scripts/default.nix
@@ -8,6 +8,14 @@
 }) {}}:
 
 let
+
+  # Hack to make Nix libreoffice wrapper work.
+  # This is because Nix wrapper breaks ghactions test by requiring the `/run/user/$(id -u)` folder to exist
+  libreofficeWithEnv = pkgs.writeShellScriptBin "soffice" ''
+    export DBUS_SESSION_BUS_ADDRESS="unix:path=/dev/null"
+    exec ${pkgs.libreoffice}/bin/soffice "$@"
+  '';
+
   yosys = import ./yosys.nix { inherit pkgs; };
 in
 pkgs.mkShell {
@@ -33,7 +41,7 @@ pkgs.mkShell {
     black
     llvmPackages_14.clangUseLLVM
     librsvg
-    libreoffice
+    libreofficeWithEnv
     minicom     # Terminal emulator
     lrzsz       # For Zmodem file transfers via serial connection of the terminal emulator
     # Add Volare custom Python installation


### PR DESCRIPTION
It seems that new versions of nix-shell treat symlinks differently than old versions.
New versions of nix-shell use the symlink directory as the root for relative paths. Unlike in old versions where the original file was the root of relative paths.

This commit replaces symlinks with Nix files using the `import` keyword. This should work on both old and new versions of nix-shell.

Resolves issue https://github.com/IObundle/iob-soc/issues/924