### PR TITLE
Fix need for ADDR-4 on preboot.S

### DIFF
--- a/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_cyclonev_wrapper/iob_soc_cyclonev_wrapper.py
+++ b/hardware/fpga/quartus/CYCLONEV-GT-DK/iob_soc_cyclonev_wrapper/iob_soc_cyclonev_wrapper.py
@@ -139,6 +139,12 @@ def setup(py_params_dict):
                     {"name": "ddr3b_dqs_p", "direction": "inout", "width": "2"},
                     {"name": "ddr3b_odt", "direction": "output", "width": "1"},
                     {"name": "ddr3b_resetn", "direction": "output", "width": "1"},
+                ],
+            },
+            {
+                "name": "rzqin",
+                "descr": "",
+                "signals": [
                     {"name": "rzqin", "direction": "input", "width": "1"},
                 ],
             },

--- a/iob_soc.py
+++ b/iob_soc.py
@@ -524,7 +524,7 @@ def setup(py_params_dict):
             "parameters": {},
             "connect": {
                 "clk_en_rst": "clk_en_rst",
-                "iob": "bootrom_csrs",
+                "cbus": "bootrom_csrs",
                 "ibus": "bootrom_i",
                 "ext_rom_bus": "rom_bus",
             },

--- a/iob_soc.py
+++ b/iob_soc.py
@@ -41,9 +41,9 @@ def setup(py_params_dict):
     }
 
     if not params["build_dir"]:
-        params["build_dir"] = (
-            f"../{attributes_dict['name']}_V{attributes_dict['version']}"
-        )
+        params[
+            "build_dir"
+        ] = f"../{attributes_dict['name']}_V{attributes_dict['version']}"
 
     attributes_dict |= {
         "build_dir": params["build_dir"],
@@ -525,8 +525,8 @@ def setup(py_params_dict):
             "connect": {
                 "clk_en_rst": "clk_en_rst",
                 "iob": "bootrom_csrs",
-                "bootrom_i_bus": "bootrom_i",
-                "boot_rom_bus": "rom_bus",
+                "ibus": "bootrom_i",
+                "ext_rom_bus": "rom_bus",
             },
         },
     ]

--- a/lib/hardware/buses/iob_axistream_in/iob_axistream_in.py
+++ b/lib/hardware/buses/iob_axistream_in/iob_axistream_in.py
@@ -4,7 +4,6 @@ def setup(py_params_dict):
         "name": "iob_axistream_in",
         "version": "0.3",
         "board_list": ["CYCLONEV-GT-DK", "AES-KU040-DB-G"],
-        "generate_hw": False,  # TODO: Delele iob_axistream_in.v source and remove this line to generate core with py2hwsw
         "confs": [
             {
                 "name": "DATA_W",
@@ -18,6 +17,7 @@ def setup(py_params_dict):
                 "name": "ADDR_W",
                 "type": "P",
                 "val": "`IOB_AXISTREAM_IN_CSRS_ADDR_W",
+                # "val": "5",
                 "min": "NA",
                 "max": "NA",
                 "descr": "Address bus width",
@@ -53,6 +53,8 @@ def setup(py_params_dict):
                 "interface": {
                     "type": "iob",
                     "subtype": "slave",
+                    "ADDR_W": "ADDR_W",
+                    "DATA_W": "DATA_W",
                 },
                 "descr": "CPU native interface",
             },
@@ -142,7 +144,79 @@ def setup(py_params_dict):
             },
         ],
         "wires": [
-            # TODO: Create wires
+            {
+                "name": "soft_reset",
+                "descr": "",
+                "signals": [
+                    {"name": "soft_reset_wr", "width": 1},
+                ],
+            },
+            {
+                "name": "enable",
+                "descr": "",
+                "signals": [
+                    {"name": "enable_wr", "width": 1},
+                ],
+            },
+            {
+                "name": "data",
+                "descr": "",
+                "signals": [
+                    {"name": "data_rdata_rd", "width": 32},
+                    {"name": "data_rvalid_rd", "width": 1},
+                    {"name": "data_ren_rd", "width": 1},
+                    {"name": "data_rready_rd", "width": 1},
+                ],
+            },
+            {
+                "name": "mode",
+                "descr": "",
+                "signals": [
+                    {"name": "mode_wr", "width": 1},
+                ],
+            },
+            {
+                "name": "nwords",
+                "descr": "",
+                "signals": [
+                    {"name": "nwords_rd", "width": "DATA_W"},
+                ],
+            },
+            {
+                "name": "tlast_detected",
+                "descr": "",
+                "signals": [
+                    {"name": "tlast_detected_rd", "width": 1},
+                ],
+            },
+            {
+                "name": "fifo_full",
+                "descr": "",
+                "signals": [
+                    {"name": "fifo_full_rd", "width": 1},
+                ],
+            },
+            {
+                "name": "fifo_empty",
+                "descr": "",
+                "signals": [
+                    {"name": "fifo_empty_rd", "width": 1},
+                ],
+            },
+            {
+                "name": "fifo_threshold",
+                "descr": "",
+                "signals": [
+                    {"name": "fifo_threshold_wr", "width": "FIFO_ADDR_W+1"},
+                ],
+            },
+            {
+                "name": "fifo_level",
+                "descr": "",
+                "signals": [
+                    {"name": "fifo_level_rd", "width": "FIFO_ADDR_W+1"},
+                ],
+            },
         ],
         "blocks": [
             {
@@ -155,7 +229,7 @@ def setup(py_params_dict):
                         "descr": "AXI Stream software accessible registers.",
                         "regs": [
                             {
-                                "name": "SOFT_RESET",
+                                "name": "soft_reset",
                                 "type": "W",
                                 "n_bits": 1,
                                 "rst_val": 0,
@@ -164,7 +238,7 @@ def setup(py_params_dict):
                                 "descr": "Soft reset.",
                             },
                             {
-                                "name": "ENABLE",
+                                "name": "enable",
                                 "type": "W",
                                 "n_bits": 1,
                                 "rst_val": 0,
@@ -173,7 +247,7 @@ def setup(py_params_dict):
                                 "descr": "Enable peripheral.",
                             },
                             {
-                                "name": "DATA",
+                                "name": "data",
                                 "type": "R",
                                 "n_bits": 32,
                                 "rst_val": 0,
@@ -182,7 +256,7 @@ def setup(py_params_dict):
                                 "descr": "Data output.",
                             },
                             {
-                                "name": "MODE",
+                                "name": "mode",
                                 "type": "W",
                                 "n_bits": "1",
                                 "rst_val": 0,
@@ -191,7 +265,7 @@ def setup(py_params_dict):
                                 "descr": "Sets the operation mode: (0) data is read using CSR; (1) data is read using system axistream interface.",
                             },
                             {
-                                "name": "NWORDS",
+                                "name": "nwords",
                                 "type": "R",
                                 "n_bits": "DATA_W",
                                 "rst_val": 0,
@@ -200,7 +274,7 @@ def setup(py_params_dict):
                                 "descr": "Read the number of words (with TDATA_W bits) written to the FIFO.",
                             },
                             {
-                                "name": "TLAST_DETECTED",
+                                "name": "tlast_detected",
                                 "type": "R",
                                 "n_bits": 1,
                                 "rst_val": 0,
@@ -215,7 +289,7 @@ def setup(py_params_dict):
                         "descr": "FIFO related registers",
                         "regs": [
                             {
-                                "name": "FIFO_FULL",
+                                "name": "fifo_full",
                                 "type": "R",
                                 "n_bits": 1,
                                 "rst_val": 0,
@@ -224,7 +298,7 @@ def setup(py_params_dict):
                                 "descr": "Full (1), or non-full (0).",
                             },
                             {
-                                "name": "FIFO_EMPTY",
+                                "name": "fifo_empty",
                                 "type": "R",
                                 "n_bits": 1,
                                 "rst_val": 0,
@@ -233,7 +307,7 @@ def setup(py_params_dict):
                                 "descr": "Full (1), or non-full (0).",
                             },
                             {
-                                "name": "FIFO_THRESHOLD",
+                                "name": "fifo_threshold",
                                 "type": "W",
                                 # FIXME: Fix csrs.py block of py2hwsw to support these parameters
                                 # "n_bits": "FIFO_ADDR_W+1",
@@ -244,7 +318,7 @@ def setup(py_params_dict):
                                 "descr": "FIFO threshold level for interrupt signal",
                             },
                             {
-                                "name": "FIFO_LEVEL",
+                                "name": "fifo_level",
                                 "type": "R",
                                 # FIXME: Fix csrs.py block of py2hwsw to support these parameters
                                 # "n_bits": "FIFO_ADDR_W+1",
@@ -261,33 +335,48 @@ def setup(py_params_dict):
                     "clk_en_rst": "clk_en_rst",
                     "control_if": "iob",
                     # Register interfaces
-                    # TODO: Connect register signals
+                    "soft_reset": "soft_reset",
+                    "enable": "enable",
+                    "data": "data",
+                    "mode": "mode",
+                    "nwords": "nwords",
+                    "tlast_detected": "tlast_detected",
+                    "fifo_full": "fifo_full",
+                    "fifo_empty": "fifo_empty",
+                    "fifo_threshold": "fifo_threshold",
+                    "fifo_level": "fifo_level",
                 },
             },
             # TODO: Connect remaining blocks
             {
                 "core_name": "iob_fifo_async",
                 "instance_name": "iob_fifo_async_inst",
+                "instantiate": False,
             },
             {
                 "core_name": "iob_reg_re",
                 "instance_name": "iob_reg_re_inst",
+                "instantiate": False,
             },
             {
                 "core_name": "iob_ram_at2p",
                 "instance_name": "iob_ram_at2p_inst",
+                "instantiate": False,
             },
             {
                 "core_name": "iob_sync",
                 "instance_name": "iob_sync_inst",
+                "instantiate": False,
             },
             {
                 "core_name": "iob_counter",
                 "instance_name": "iob_counter_inst",
+                "instantiate": False,
             },
             {
                 "core_name": "iob_edge_detect",
                 "instance_name": "iob_edge_detect_inst",
+                "instantiate": False,
             },
         ],
     }

--- a/lib/hardware/buses/iob_axistream_out/hardware/src/iob_axistream_out.v
+++ b/lib/hardware/buses/iob_axistream_out/hardware/src/iob_axistream_out.v
@@ -41,8 +41,10 @@ module iob_axistream_out #(
    wire [RAM_ADDR_W-1:0] ext_mem_r_addr;
    wire [    DATA_W-1:0] ext_mem_r_data;
 
+   `include "iob_axistream_out_wires.vs"
+
    // configuration control and status register file.
-   `include "iob_axistream_out_csrs_inst.vs"
+   `include "iob_axistream_out_blocks.vs"
 
    //AXI Stream interface
    assign axis_tvalid_o = axis_tvalid;
@@ -50,17 +52,17 @@ module iob_axistream_out #(
    assign axis_tlast_o = (axis_word_count == axis_nwords) & axis_tvalid_o;
 
    //CPU interface
-   assign DATA_wready_wr = ~FIFO_FULL_rd;
-   assign interrupt_o = FIFO_LEVEL_rd <= FIFO_THRESHOLD_wr;
+   assign data_wready_wr = ~fifo_full_rd;
+   assign interrupt_o = fifo_level_rd <= fifo_threshold_wr;
 
    //DMA data ready
-   assign sys_tready_o = ~FIFO_FULL_rd & axis_sw_enable & (MODE_wr == 1'b1);
+   assign sys_tready_o = ~fifo_full_rd & axis_sw_enable & (mode_wr == 1'b1);
 
    //FIFO write
-   assign fifo_write     = ((DATA_wen_wr & (MODE_wr == 1'b0)) |
-                           (sys_tvalid_i & (MODE_wr == 1'b1))) &
+   assign fifo_write     = ((data_wen_wr & (mode_wr == 1'b0)) |
+                           (sys_tvalid_i & (mode_wr == 1'b1))) &
                            axis_sw_enable;
-   assign fifo_wdata = sys_tvalid_i == 1'b1 ? sys_tdata_i : DATA_wdata_wr;
+   assign fifo_wdata = sys_tvalid_i == 1'b1 ? sys_tdata_i : data_wdata_wr;
 
    //FIFO read
    always @* begin
@@ -134,7 +136,7 @@ module iob_axistream_out #(
    ) sw_rst (
       .clk_i   (axis_clk_i),
       .arst_i  (axis_arst_i),
-      .signal_i(SOFT_RESET_wr),
+      .signal_i(soft_reset_wr),
       .signal_o(axis_sw_rst)
    );
 
@@ -144,7 +146,7 @@ module iob_axistream_out #(
    ) sw_enable (
       .clk_i   (axis_clk_i),
       .arst_i  (axis_arst_i),
-      .signal_i(ENABLE_wr),
+      .signal_i(enable_wr),
       .signal_o(axis_sw_enable)
    );
 
@@ -154,7 +156,7 @@ module iob_axistream_out #(
    ) fifo_threshold (
       .clk_i   (axis_clk_i),
       .arst_i  (axis_arst_i),
-      .signal_i(NWORDS_wr),
+      .signal_i(nwords_wr),
       .signal_o(axis_nwords)
    );
 
@@ -210,12 +212,12 @@ module iob_axistream_out #(
       .w_clk_i         (clk_i),
       .w_cke_i         (cke_i),
       .w_arst_i        (arst_i),
-      .w_rst_i         (SOFT_RESET_wr),
+      .w_rst_i         (soft_reset_wr),
       .w_en_i          (fifo_write),
       .w_data_i        (fifo_wdata),
-      .w_empty_o       (FIFO_EMPTY_rd),
-      .w_full_o        (FIFO_FULL_rd),
-      .w_level_o       (FIFO_LEVEL_rd)
+      .w_empty_o       (fifo_empty_rd),
+      .w_full_o        (fifo_full_rd),
+      .w_level_o       (fifo_level_rd)
    );
 
 endmodule

--- a/lib/hardware/iob_regfileif/iob_regfileif.py
+++ b/lib/hardware/iob_regfileif/iob_regfileif.py
@@ -7,6 +7,7 @@ def setup(py_params_dict):
         "version": "0.7",
         "internal_csr_if": "iob",
         "external_csr_if": "iob",
+        # FIXME: Make ADDR_W automatic
         "internal_csr_if_widths": {"ADDR_W": 32, "DATA_W": 32},
         "external_csr_if_widths": {"ADDR_W": 32, "DATA_W": 32},
         "csrs": [],
@@ -55,6 +56,16 @@ def setup(py_params_dict):
                     },
                 ],
             }
+        ]
+        confs = [
+            {
+                "name": "DATA_W",
+                "type": "P",
+                "val": "32",
+                "min": "0",
+                "max": "32",
+                "descr": "Data bus width",
+            },
         ]
 
     assert params["csrs"], "Error: Register list empty."
@@ -109,15 +120,16 @@ def setup(py_params_dict):
             if csr["type"] == "RW":
                 internal_reg_connections[csr["name"]] = csr["name"] + "_inv"
 
+    if py_params_dict["instantiator"]:
+        confs = py_params_dict["instantiator"]["confs"]
+
     attributes_dict = {
         "original_name": "iob_regfileif",
         "name": "iob_regfileif",
         "version": "0.1",
     }
     attributes_dict |= {
-        "confs": [
-            # TODO:
-        ],
+        "confs": confs,
         "ports": [
             {
                 "name": "clk_en_rst",

--- a/lib/scripts/default.nix
+++ b/lib/scripts/default.nix
@@ -1,8 +1,8 @@
 { pkgs ? import <nixpkgs> {} }:
 
 let
-  py2hwsw_commit = "1b71af5c06333e63ea247bad0dc6511d10bf2746"; # Replace with the desired commit.
-  py2hwsw_sha256 = "+zDYS1TGqYIuu/iEhO4gUNrfkFX85FYjFO3BPPn9Nes="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "8757e540950890827ec6e42d1ca2ace1798a00b9"; # Replace with the desired commit.
+  py2hwsw_sha256 = "Z/N4yfeZ5b06trlYf+cirCHC7vHqVksxZT2XZKFlCd8="; # Replace with the actual SHA256 hash.
 
   py2hwsw = pkgs.python3.pkgs.buildPythonPackage rec {
     pname = "py2hwsw";

--- a/submodules/BOOTROM/hardware/src/iob_bootrom.v
+++ b/submodules/BOOTROM/hardware/src/iob_bootrom.v
@@ -10,10 +10,10 @@ module iob_bootrom #(
         `include "iob_bootrom_io.vs"
     );
 
-    `include "iob_axistream_in_wires.vs"
+    `include "iob_bootrom_wires.vs"
 
     // configuration control and status register file.
-    `include "iob_axistream_in_blocks.vs"
+    `include "iob_bootrom_blocks.vs"
 
     // Instantiate preboot ROM //
 

--- a/submodules/BOOTROM/hardware/src/iob_bootrom.v
+++ b/submodules/BOOTROM/hardware/src/iob_bootrom.v
@@ -10,7 +10,10 @@ module iob_bootrom #(
         `include "iob_bootrom_io.vs"
     );
 
-    `include "iob_bootrom_csrs_inst.vs"
+    `include "iob_axistream_in_wires.vs"
+
+    // configuration control and status register file.
+    `include "iob_axistream_in_blocks.vs"
 
     // Instantiate preboot ROM //
 

--- a/submodules/BOOTROM/hardware/src/iob_bootrom.v
+++ b/submodules/BOOTROM/hardware/src/iob_bootrom.v
@@ -22,13 +22,13 @@ module iob_bootrom #(
         .clk_i(clk_i),
 
         //instruction memory interface
-        .r_en_i  (bootrom_i_iob_valid_i),
-        .addr_i  (bootrom_i_iob_addr_i[2 +: PREBOOTROM_ADDR_W-2]),
-        .r_data_o(bootrom_i_iob_rdata_o)
+        .r_en_i  (ibus_iob_valid_i),
+        .addr_i  (ibus_iob_addr_i[2 +: PREBOOTROM_ADDR_W-2]),
+        .r_data_o(ibus_iob_rdata_o)
     );
 
-   
-    assign bootrom_i_iob_ready_o = 1'b1; // ROM is always ready
+
+    assign ibus_iob_ready_o = 1'b1; // ROM is always ready
     iob_reg #(
         .DATA_W (1),
         .RST_VAL(0)
@@ -36,16 +36,17 @@ module iob_bootrom #(
         .clk_i (clk_i),
         .cke_i (cke_i),
         .arst_i(arst_i),
-        .data_i(bootrom_i_iob_valid_i),
-        .data_o(bootrom_i_iob_rvalid_o)
+        .data_i(ibus_iob_valid_i),
+        .data_o(ibus_iob_rvalid_o)
     );
 
     // Link to boot ROM //
 
-    assign boot_rom_en_o = ROM_ren_rd;
-    assign boot_rom_addr_o = iob_addr_i[2 +: BOOTROM_ADDR_W-2];
-    assign ROM_rdata_rd = boot_rom_rdata_i;
+    assign ext_rom_en_o = ROM_ren_rd;
+    assign ext_rom_addr_o = iob_addr_i[2 +: BOOTROM_ADDR_W-2];
+    assign ROM_rdata_rd = ext_rom_rdata_i;
     assign ROM_rready_rd = 1'b1; // ROM is always ready
+    reg ROM_rvalid_rd_middle; // Registered twice to align rvalid with rdata
     iob_reg #(
         .DATA_W (1),
         .RST_VAL(0)
@@ -54,6 +55,16 @@ module iob_bootrom #(
         .cke_i (cke_i),
         .arst_i(arst_i),
         .data_i(iob_valid_i),
+        .data_o(ROM_rvalid_rd_middle)
+    );
+    iob_reg #(
+        .DATA_W (1),
+        .RST_VAL(0)
+    ) rom_rvalid_r_2nd (
+        .clk_i (clk_i),
+        .cke_i (cke_i),
+        .arst_i(arst_i),
+        .data_i(ROM_rvalid_rd_middle),
         .data_o(ROM_rvalid_rd)
     );
 

--- a/submodules/BOOTROM/iob_bootrom.py
+++ b/submodules/BOOTROM/iob_bootrom.py
@@ -54,11 +54,10 @@ def setup(py_params_dict):
                 "descr": "Clock and reset",
             },
             {
-                "name": "cbus",
+                "name": "iob",
                 "interface": {
                     "type": "iob",
                     "subtype": "slave",
-                    "port_prefix": "cbus_",
                     "ADDR_W": "`IOB_BOOTROM_CSRS_ADDR_W",
                     "DATA_W": "DATA_W",
                 },

--- a/submodules/BOOTROM/iob_bootrom.py
+++ b/submodules/BOOTROM/iob_bootrom.py
@@ -54,10 +54,11 @@ def setup(py_params_dict):
                 "descr": "Clock and reset",
             },
             {
-                "name": "iob",
+                "name": "cbus",
                 "interface": {
                     "type": "iob",
                     "subtype": "slave",
+                    "port_prefix": "cbus_",
                     "ADDR_W": "`IOB_BOOTROM_CSRS_ADDR_W",
                     "DATA_W": "DATA_W",
                 },

--- a/submodules/BOOTROM/software/src/iob_soc_preboot.S
+++ b/submodules/BOOTROM/software/src/iob_soc_preboot.S
@@ -14,10 +14,9 @@
 .globl _start
 
 _start:
-  li x1, LENGTH + 1
+  li x1, LENGTH
   li x2, BOOTROM
-  // Below, -4 because it was only starting to write at 0x4 for some reason
-  li x3, BOOTLDR_ADDR - 4
+  li x3, BOOTLDR_ADDR
 
 copy_loop:
   lw x4, 0(x2)


### PR DESCRIPTION
bootrom.v has issues with new py2hwsw version. Old csrs_inst.vs no longer exists and new attempt at replacing it is broken.