### PR TITLE
Pass `iob_soc` attributes via python parameters to `iob_system` parent. 

### DIFF
--- a/iob_soc.py
+++ b/iob_soc.py
@@ -18,7 +18,7 @@ def setup(py_params_dict):
                 "core_name": "iob_uart",
                 "instance_name": "UART0",
                 "instance_description": "UART peripheral",
-                "is_peripheral": True,
+                "peripheral_addr_w": 3,
                 "parameters": {},
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
@@ -26,7 +26,10 @@ def setup(py_params_dict):
                     # The iob_system blocks are handled by iob_system_utils.py, but
                     # the iob_system scripts do not have access to info in iob_soc.py,
                     # nor do they have permission to modify it (even if iob_system receives info about child module, it can't modify its dictionary).
-                    "cbus_s": "uart0_cbus",
+                    "cbus_s": (
+                        "uart0_cbus",
+                        "uart0_cbus_iob_addr[3-1:0]",
+                    ),
                     "rs232_m": "rs232_m",
                 },
             },
@@ -34,12 +37,15 @@ def setup(py_params_dict):
                 "core_name": "iob_timer",
                 "instance_name": "TIMER0",
                 "instance_description": "Timer peripheral",
-                "is_peripheral": True,
+                "peripheral_addr_w": 4,
                 "parameters": {},
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
                     # TODO: Cbus should be connected automatically
-                    "cbus_s": "timer0_cbus",
+                    "cbus_s": (
+                        "timer0_cbus",
+                        "timer0_cbus_iob_addr[4-1:0]",
+                    ),
                 },
             },
         ],

--- a/iob_soc.py
+++ b/iob_soc.py
@@ -19,9 +19,7 @@ def setup(py_params_dict):
                 "instance_name": "UART0",
                 "instance_description": "UART peripheral",
                 "is_peripheral": True,
-                "parameters": {
-                    "ADDR_W": "29",  # TODO: Automate this with iob_system scripts
-                },
+                "parameters": {},
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
                     # TODO: Cbus should be connected automatically
@@ -37,9 +35,7 @@ def setup(py_params_dict):
                 "instance_name": "TIMER0",
                 "instance_description": "Timer peripheral",
                 "is_peripheral": True,
-                "parameters": {
-                    "ADDR_W": "29",  # TODO: Automate this with iob_system scripts
-                },
+                "parameters": {},
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
                     # TODO: Cbus should be connected automatically

--- a/iob_soc.py
+++ b/iob_soc.py
@@ -1,9 +1,14 @@
 def setup(py_params_dict):
-    attributes_dict = {
+    # Py2hwsw dictionary describing current core
+    core_dict = {
         "original_name": "iob_soc",
         "name": "iob_soc",
-        "parent": {"core_name": "iob_system", **py_params_dict},
         "version": "0.1",
+        "parent": {"core_name": "iob_system", **py_params_dict},
+    }
+
+    # Dictionary of "iob_system" attributes to override/append
+    system_overrides = {
         "ports": [
             {
                 "name": "rs232_m",
@@ -22,14 +27,7 @@ def setup(py_params_dict):
                 "parameters": {},
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
-                    # TODO: Cbus should be connected automatically
-                    # The iob_system blocks are handled by iob_system_utils.py, but
-                    # the iob_system scripts do not have access to info in iob_soc.py,
-                    # nor do they have permission to modify it (even if iob_system receives info about child module, it can't modify its dictionary).
-                    "cbus_s": (
-                        "uart0_cbus",
-                        "uart0_cbus_iob_addr[3-1:0]",
-                    ),
+                    # Cbus connected automatically
                     "rs232_m": "rs232_m",
                 },
             },
@@ -41,14 +39,13 @@ def setup(py_params_dict):
                 "parameters": {},
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
-                    # TODO: Cbus should be connected automatically
-                    "cbus_s": (
-                        "timer0_cbus",
-                        "timer0_cbus_iob_addr[4-1:0]",
-                    ),
+                    # Cbus connected automatically
                 },
             },
         ],
     }
 
-    return attributes_dict
+    # Pass system_overrides dictionary via python parameter to the parent core (iob_system)
+    core_dict["parent"]["system_overrides"] = system_overrides
+
+    return core_dict

--- a/lib/hardware/clocks_resets/iob_nco/iob_nco.py
+++ b/lib/hardware/clocks_resets/iob_nco/iob_nco.py
@@ -39,11 +39,11 @@ def setup(py_params_dict):
                 "descr": "clock, clock enable and reset",
             },
             {
-                "name": "cbus_s",
+                "name": "iob_s",
                 "interface": {
                     "type": "iob",
                     "subtype": "slave",
-                    "ADDR_W": "ADDR_W",
+                    "ADDR_W": "4",  # Same as `IOB_NCO_CSRS_ADDR_W
                     "DATA_W": "DATA_W",
                 },
                 "descr": "CPU native interface",
@@ -80,7 +80,7 @@ def setup(py_params_dict):
                 "interface": {
                     "type": "iob",
                     "wire_prefix": "csrs_",
-                    "ADDR_W": "4",
+                    "ADDR_W": "ADDR_W",
                     "DATA_W": "DATA_W",
                 },
             },
@@ -311,10 +311,7 @@ def setup(py_params_dict):
                 ],
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
-                    "control_if_s": (
-                        "cbus_s",
-                        "iob_addr_i[4-1:0]",
-                    ),
+                    "control_if_s": "iob_s",
                     "csrs_iob_o": "csrs_iob",
                     # Register interfaces
                     "softreset": "softreset",

--- a/lib/hardware/iob_system/iob_system.py
+++ b/lib/hardware/iob_system/iob_system.py
@@ -426,7 +426,7 @@ def setup(py_params_dict):
             "core_name": "iob_uart",
             "instance_name": "UART0",
             "instance_description": "UART peripheral",
-            "is_peripheral": True,
+            "peripheral_addr_w": 3,
             "parameters": {},
             "connect": {
                 "clk_en_rst_s": "clk_en_rst_s",
@@ -438,14 +438,14 @@ def setup(py_params_dict):
             "core_name": "iob_timer",
             "instance_name": "TIMER0",
             "instance_description": "Timer peripheral",
-            "is_peripheral": True,
+            "peripheral_addr_w": 4,
             "parameters": {},
             "connect": {
                 "clk_en_rst_s": "clk_en_rst_s",
                 # Cbus connected automatically
             },
         },
-        # NOTE: Instantiate other peripherals here, using the 'is_peripheral' flag
+        # NOTE: Instantiate other peripherals here, using the 'peripheral_addr_w' flag
         #
         # Modules that need to be setup, but are not instantiated directly inside
         # 'iob_system' Verilog module

--- a/lib/hardware/iob_system/scripts/iob_system_utils.py
+++ b/lib/hardware/iob_system/scripts/iob_system_utils.py
@@ -52,14 +52,14 @@ def set_build_dir(attributes_dict, py_params):
 
 
 def get_iob_system_peripherals_list(attributes_dict):
-    """Parses blocks list in iob_system attributes, for blocks with the `is_peripheral` attribute set to True.
-    Also removes `is_peripheral` attribute from each block after adding it to the peripherals list.
+    """Parses blocks list in iob_system attributes, for blocks with the `peripheral_addr_w` attribute set.
+    Also removes `peripheral_addr_w` attribute from each block after adding it to the peripherals list.
     """
     peripherals = []
     for block in attributes_dict["blocks"]:
-        if "is_peripheral" in block and block["is_peripheral"]:
-            peripherals.append(block)
-            block.pop("is_peripheral")
+        if "peripheral_addr_w" in block and block["peripheral_addr_w"]:
+            peripherals.append({"ref": block, "addr_w": block["peripheral_addr_w"]})
+            block.pop("peripheral_addr_w")
     return peripherals
 
 
@@ -83,7 +83,7 @@ def connect_peripherals_cbus(attributes_dict, peripherals, params):
     pbus_split["num_outputs"] = num_peripherals
 
     for idx, peripheral in enumerate(peripherals):
-        peripheral_name = peripheral["instance_name"].lower()
+        peripheral_name = peripheral["ref"]["instance_name"].lower()
         # Add peripheral cbus wire
         attributes_dict["wires"].append(
             {
@@ -99,7 +99,10 @@ def connect_peripherals_cbus(attributes_dict, peripherals, params):
         # Connect cbus to pbus_split
         pbus_split["connect"][f"output_{idx}_m"] = f"{peripheral_name}_cbus"
         # Connect cbus to peripheral
-        peripheral["connect"]["cbus_s"] = f"{peripheral_name}_cbus"
+        peripheral["ref"]["connect"]["cbus_s"] = (
+            f"{peripheral_name}_cbus",
+            f"{peripheral_name}_cbus_iob_addr[{peripheral["addr_w"]}-1:0]",
+        )
 
     # Add CLINT and PLIC wires (they are not in peripherals list)
     attributes_dict["wires"] += [
@@ -146,8 +149,8 @@ def generate_peripheral_base_addresses(
 
     # Include CLINT and PLIC in peripherals list
     complete_peripherals_list = peripherals_list + [
-        {"instance_name": "CLINT0"},
-        {"instance_name": "PLIC0"},
+        {"ref": {"instance_name": "CLINT0"}},
+        {"ref": {"instance_name": "PLIC0"}},
     ]
     n_slaves_w = (len(complete_peripherals_list) - 1).bit_length()
 
@@ -158,7 +161,7 @@ def generate_peripheral_base_addresses(
     os.makedirs(os.path.dirname(out_file), exist_ok=True)
     with open(out_file, "w") as f:
         for idx, instance in enumerate(complete_peripherals_list):
-            instance_name = instance["instance_name"]
+            instance_name = instance["ref"]["instance_name"]
             f.write(
                 f"#define {instance_name}_BASE (PBUS_BASE + ({idx}<<(P_BIT-{n_slaves_w})))\n"
             )
@@ -187,7 +190,7 @@ def generate_makefile_segments(attributes_dict, peripherals, params, py_params):
         # Create a list with every peripheral name, except clint, and plic
         file.write(
             "PERIPHERALS ?="
-            + " ".join(peripheral["core_name"] for peripheral in peripherals)
+            + " ".join(peripheral["ref"]["core_name"] for peripheral in peripherals)
             + "\n",
         )
         if params["use_ethernet"]:

--- a/lib/hardware/iob_system/scripts/iob_system_utils.py
+++ b/lib/hardware/iob_system/scripts/iob_system_utils.py
@@ -100,8 +100,6 @@ def connect_peripherals_cbus(attributes_dict, peripherals, params):
         pbus_split["connect"][f"output_{idx}_m"] = f"{peripheral_name}_cbus"
         # Connect cbus to peripheral
         peripheral["connect"]["cbus_s"] = f"{peripheral_name}_cbus"
-        # Set address width parameter
-        peripheral["parameters"]["ADDR_W"] = peripheral_addr_w
 
     # Add CLINT and PLIC wires (they are not in peripherals list)
     attributes_dict["wires"] += [

--- a/lib/hardware/iob_timer/iob_timer.py
+++ b/lib/hardware/iob_timer/iob_timer.py
@@ -43,7 +43,7 @@ def setup(py_params_dict):
                 "interface": {
                     "type": "iob",
                     "subtype": "slave",
-                    "ADDR_W": "ADDR_W",
+                    "ADDR_W": "4",  # Same as `IOB_TIMER_CSRS_ADDR_W
                     "DATA_W": "DATA_W",
                 },
                 "descr": "CPU native interface",
@@ -56,7 +56,7 @@ def setup(py_params_dict):
                 "interface": {
                     "type": "iob",
                     "wire_prefix": "csrs_",
-                    "ADDR_W": "4",
+                    "ADDR_W": "ADDR_W",
                     "DATA_W": "DATA_W",
                 },
             },
@@ -177,10 +177,7 @@ def setup(py_params_dict):
                 "csr_if": "iob",
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
-                    "control_if_s": (
-                        "cbus_s",
-                        "iob_addr_i[4-1:0]",
-                    ),
+                    "control_if_s": "cbus_s",
                     "csrs_iob_o": "csrs_iob",
                     # Register interfaces
                     "reset": "reset",

--- a/lib/hardware/iob_uart/iob_uart.py
+++ b/lib/hardware/iob_uart/iob_uart.py
@@ -1,17 +1,6 @@
 def setup(py_params_dict):
     CSR_IF = py_params_dict["csr_if"] if "csr_if" in py_params_dict else "iob"
     NAME = py_params_dict["name"] if "name" in py_params_dict else "iob_uart"
-
-    if CSR_IF == "iob":
-        cbus_widths = ["iob_addr_i[3-1:0]"]
-    elif CSR_IF == "axi":
-        cbus_widths = [
-            "axi_araddr_i[3-1:0]",
-            "axi_awaddr_i[3-1:0]",
-        ]
-    else:
-        cbus_widths = []
-
     attributes_dict = {
         "original_name": "iob_uart",
         "name": NAME,
@@ -57,7 +46,7 @@ def setup(py_params_dict):
                 "interface": {
                     "type": CSR_IF,
                     "subtype": "slave",
-                    "ADDR_W": "ADDR_W",
+                    "ADDR_W": "3",  # Same as `IOB_UART_CSRS_ADDR_W
                     "DATA_W": "DATA_W",
                 },
                 "descr": "CPU native interface",
@@ -77,7 +66,7 @@ def setup(py_params_dict):
                 "interface": {
                     "type": "iob",
                     "wire_prefix": "csrs_",
-                    "ADDR_W": "3",
+                    "ADDR_W": "ADDR_W",
                     "DATA_W": "DATA_W",
                 },
             },
@@ -283,7 +272,7 @@ def setup(py_params_dict):
                 "csr_if": CSR_IF,
                 "connect": {
                     "clk_en_rst_s": "clk_en_rst_s",
-                    "control_if_s": ("cbus_s", *cbus_widths),
+                    "control_if_s": "cbus_s",
                     "csrs_iob_o": "csrs_iob",
                     # Register interfaces
                     "softreset": "softreset",

--- a/lib/scripts/default.nix
+++ b/lib/scripts/default.nix
@@ -1,8 +1,8 @@
 { pkgs ? import <nixpkgs> {} }:
 
 let
-  py2hwsw_commit = "8abbad6b93b9cfcca4fb97bdd4d09cadf8cadbe2"; # Replace with the desired commit.
-  py2hwsw_sha256 = "NIxU15GH3YtFYeYW1bfZJgobEs0Bk25yU7pNiXnE/IA="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "db8edfe33d2790cd7d779ec9537187b1edbad5d6"; # Replace with the desired commit.
+  py2hwsw_sha256 = "Y4J8l5U2SCjrx692L9UXuB3VVOlXwE1tV7j7XbU/TCo="; # Replace with the actual SHA256 hash.
 
   py2hwsw = pkgs.python3.pkgs.buildPythonPackage rec {
     pname = "py2hwsw";


### PR DESCRIPTION
- New `iob_soc.py` passes attributes to parent core (iob_system) via python parameters.
  This allows iob_system scripts to automate features from iob_soc attributes (like peripheral cbus connections).
- Replace iob_system `is_peripheral` attribute by `peripheral_addr_w`.
- Update py2hwsw version to match the one from PR https://github.com/IObundle/py2hwsw/pull/50.