### PR TITLE
fix(doc): fix typos, signature, master/slave

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,20 +102,6 @@ jobs:
       - name: run uart test
         run: make -C submodules/UART test
 
-  cache:
-    runs-on: self-hosted
-    timeout-minutes: 20
-    if: ${{ !cancelled() }}
-    needs: [ cyclonev ]
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
-      - name: run simulation test
-        run: make -C submodules/CACHE sim-test
-      - name: run fpga test
-        run: make -C submodules/CACHE fpga-test
   doc:
     runs-on: self-hosted
     timeout-minutes: 60

--- a/submodules/LIB/document/Makefile
+++ b/submodules/LIB/document/Makefile
@@ -23,8 +23,14 @@ TSRC = $(patsubst tsrc/%, ./%, $(wildcard tsrc/*))
 	cp $< $@
 
 TSRC+=signature.tex
-signature.tex:
-	 @echo `cat name.tex`-USG-`cat version.tex`-`cat shortHash.tex` > signature.tex
+signature.tex: $(DOC)_signature.tex
+	mv $< $@
+
+ug_signature.tex pb_signature.tex:
+	@echo `cat name.tex`-USG-`cat $(NAME)_version.tex`-`cat shortHash.tex` > $@
+
+rn_signature.tex:
+	@echo `cat name.tex`-REL-`cat $(NAME)_version.tex`-`cat shortHash.tex` > $@
 
 #make figures
 figs:

--- a/submodules/LIB/document/tsrc/config.tex
+++ b/submodules/LIB/document/tsrc/config.tex
@@ -1,7 +1,7 @@
 Table~\ref{tab:confs} describes the IP core configuration. The core may be configured using macros or parameters:
 
 \begin{description}
-\item \textbf{'M'} Macro: a Verilog macro or ``\`define'' directive is used to include or exclude code segments, to create core configurations that are valid for all instances of the core.
+    \item \textbf{'M'} Macro: a Verilog macro or \texttt{define} directive is used to include or exclude code segments, to create core configurations that are valid for all instances of the core.
 \item \textbf{'P'} Parameter: a Verilog parameter is passed to each instance of the core and defines the configuration of that particular instance.
 \end{description}
 

--- a/submodules/LIB/scripts/if_gen.py
+++ b/submodules/LIB/scripts/if_gen.py
@@ -943,7 +943,7 @@ axi_write = [
         "width": AXI_CACHE_W,
         "name": "axi_awcache",
         "default": "2",
-        "description": "Address write channel memory type. Set to 0000 if master output; ignored if slave input.",
+        "description": "Address write channel memory type. Set to 0000 if manager output; ignored if slave input.",
     },
     {
         "lite": 1,
@@ -953,7 +953,7 @@ axi_write = [
         "width": AXI_PROT_W,
         "name": "axi_awprot",
         "default": "2",
-        "description": "Address write channel protection type. Set to 000 if master output; ignored if slave input.",
+        "description": "Address write channel protection type. Set to 000 if manager output; ignored if subordinate input.",
     },
     {
         "lite": 0,
@@ -1146,7 +1146,7 @@ axi_read = [
         "width": AXI_CACHE_W,
         "name": "axi_arcache",
         "default": "2",
-        "description": "Address read channel memory type. Set to 0000 if master output; ignored if slave input.",
+        "description": "Address read channel memory type. Set to 0000 if manager output; ignored if subordinate input.",
     },
     {
         "lite": 1,
@@ -1156,7 +1156,7 @@ axi_read = [
         "width": AXI_PROT_W,
         "name": "axi_arprot",
         "default": "2",
-        "description": "Address read channel protection type. Set to 000 if master output; ignored if slave input.",
+        "description": "Address read channel protection type. Set to 000 if manager output; ignored if subordinate input.",
     },
     {
         "lite": 0,
@@ -1303,7 +1303,7 @@ amba = [
         "width": AHB_PROT_W,
         "name": "ahb_prot",
         "default": "1",
-        "description": "Protection type. Set to 0000 if master output; ignored if slave input.",
+        "description": "Protection type. Set to 0000 if manager output; ignored if subordinate input.",
     },
     {
         "ahb": 1,
@@ -1369,7 +1369,7 @@ amba = [
         "width": "1",
         "name": "ahb_sel",
         "default": "0",
-        "description": "Slave select.",
+        "description": "subordinate select.",
     },
     {
         "ahb": 0,
@@ -1479,7 +1479,7 @@ amba = [
         "width": "1",
         "name": "ahb_slverr",
         "default": "0",
-        "description": "Slave error. Indicates if the transfer has falied.",
+        "description": "subordinate error. Indicates if the transfer has falied.",
     },
 ]
 


### PR DESCRIPTION
- fix documentation typos
- fix document signature:
    - distinguish user guide from release
    - add version tag
- remove master slave references from standard interface comments