### PR TITLE
fix(hw): rm wire declaration and assign

### DIFF
--- a/submodules/LIB/hardware/modules/counter/iob_counter_ld/hardware/src/iob_counter_ld.v
+++ b/submodules/LIB/hardware/modules/counter/iob_counter_ld/hardware/src/iob_counter_ld.v
@@ -12,7 +12,8 @@ module iob_counter_ld #(
    output [DATA_W-1:0] data_o
 );
 
-   wire [DATA_W-1:0] data = ld_i ? ld_val_i : data_o + 1'b1;
+   wire [DATA_W-1:0] data;
+   assign data = ld_i ? ld_val_i : data_o + 1'b1;
 
    iob_reg_re #(
       .DATA_W (DATA_W),

--- a/submodules/LIB/hardware/modules/counter/iob_modcnt/hardware/src/iob_modcnt.v
+++ b/submodules/LIB/hardware/modules/counter/iob_modcnt/hardware/src/iob_modcnt.v
@@ -14,8 +14,11 @@ module iob_modcnt #(
    output [DATA_W-1:0] data_o
 );
 
-   wire ld_count = (data_o >= mod_i);
-   wire                               [DATA_W-1:0] ld_val = {DATA_W{1'b0}};
+   wire ld_count;
+   wire [DATA_W-1:0] ld_val;
+
+   assign ld_count = (data_o >= mod_i);
+   assign ld_val = {DATA_W{1'b0}};
 
    iob_counter_ld #(
       .DATA_W (DATA_W),

--- a/submodules/LIB/hardware/modules/div/iob_div_subshift/hardware/src/iob_div_subshift.v
+++ b/submodules/LIB/hardware/modules/div/iob_div_subshift/hardware/src/iob_div_subshift.v
@@ -41,7 +41,8 @@ module iob_div_subshift #(
       .data_o(divisor_reg)
    );
 
-   wire [DATA_W-1:0] subtraend = dqr_reg[(2*DATA_W)-2-:DATA_W];
+   wire [DATA_W-1:0] subtraend;
+   assign subtraend = dqr_reg[(2*DATA_W)-2-:DATA_W];
    wire  [  DATA_W:0] tmp;
 
    //output quotient and remainder
@@ -58,10 +59,6 @@ module iob_div_subshift #(
    reg [$clog2(DATA_W+1)-1:0] pcnt_nxt;  //program counter
    wire [$clog2(DATA_W+1)-1:0] pcnt;
    
-   /* verilator lint_off WIDTH */   
-   wire [$clog2(DATA_W+1)-1:0] last_stage = DATA_W + 1;
-   /* verilator lint_on WIDTH */
-
    iob_reg #(
        .DATA_W($clog2(DATA_W+1)),
        .RST_VAL({($clog2(DATA_W+1)){1'b0}})
@@ -86,7 +83,7 @@ module iob_div_subshift #(
             divisor_nxt = divisor_i;
             dqr_nxt     = {1'b0,{DATA_W{1'b0}}, dividend_i};
          end         
-      end else if (pcnt == last_stage) begin
+      end else if (pcnt == (DATA_W+1)) begin
          pcnt_nxt = 0;
       end else begin //shift and subtract
          done_o = 1'b0;

--- a/submodules/LIB/hardware/modules/div/iob_div_subshift_signed/hardware/src/iob_div_subshift_signed.v
+++ b/submodules/LIB/hardware/modules/div/iob_div_subshift_signed/hardware/src/iob_div_subshift_signed.v
@@ -22,9 +22,10 @@ module iob_div_subshift_signed #(
    reg               divident_sign;
    reg               divisor_sign;
    reg  [  PC_W-1:0] pc;  //program counter
-   wire [DATA_W-1:0] subtraend = rq[2*DATA_W-2-:DATA_W];
+   wire [DATA_W-1:0] subtraend;
    reg  [  DATA_W:0] tmp;
 
+   assign subtraend = rq[2*DATA_W-2-:DATA_W];
    //output quotient and remainder
    assign quotient_o  = rq[DATA_W-1:0];
    assign remainder_o = rq[2*DATA_W-1:DATA_W];

--- a/submodules/LIB/hardware/modules/fifo/iob_fifo_async/hardware/src/iob_fifo_async.v
+++ b/submodules/LIB/hardware/modules/fifo/iob_fifo_async/hardware/src/iob_fifo_async.v
@@ -138,7 +138,8 @@ module iob_fifo_async #(
 
 
    //read address gray code counter
-   wire r_en_int = (r_en_i & (~r_empty_o));
+   wire r_en_int;
+   assign r_en_int = (r_en_i & (~r_empty_o));
    iob_gray_counter #(
       .W(R_ADDR_W + 1)
    ) r_raddr_gray_counter (
@@ -151,7 +152,8 @@ module iob_fifo_async #(
    );
 
    //write address gray code counter
-   wire w_en_int = (w_en_i & (~w_full_o));
+   wire w_en_int;
+   assign w_en_int = (w_en_i & (~w_full_o));
    iob_gray_counter #(
       .W(W_ADDR_W + 1)
    ) w_waddr_gray_counter (
@@ -195,8 +197,10 @@ module iob_fifo_async #(
       .bin_o(w_raddr_bin)
    );
 
-   wire [W_ADDR_W-1:0] w_addr = w_waddr_bin[W_ADDR_W-1:0];
-   wire [R_ADDR_W-1:0] r_addr = r_raddr_bin[R_ADDR_W-1:0];
+   wire [W_ADDR_W-1:0] w_addr;
+   wire [R_ADDR_W-1:0] r_addr;
+   assign w_addr = w_waddr_bin[W_ADDR_W-1:0];
+   assign r_addr = r_raddr_bin[R_ADDR_W-1:0];
 
    assign ext_mem_w_clk_o = w_clk_i;
    assign ext_mem_r_clk_o = r_clk_i;

--- a/submodules/LIB/hardware/modules/fifo/iob_fifo_sync/hardware/src/iob_fifo_sync.v
+++ b/submodules/LIB/hardware/modules/fifo/iob_fifo_sync/hardware/src/iob_fifo_sync.v
@@ -48,7 +48,8 @@ module iob_fifo_sync #(
    localparam [ADDR_W:0] FIFO_SIZE = {1'b1, {ADDR_W{1'b0}}};  //in bytes
 
    //effective write enable
-   wire                w_en_int = (w_en_i & (~w_full_o));
+   wire w_en_int;
+   assign w_en_int = (w_en_i & (~w_full_o));
 
    //write address
    wire [W_ADDR_W-1:0] w_addr;
@@ -64,7 +65,8 @@ module iob_fifo_sync #(
    );
 
    //effective read enable
-   wire                r_en_int = (r_en_i & (~r_empty_o));
+   wire r_en_int;
+   assign r_en_int = (r_en_i & (~r_empty_o));
 
    //read address
    wire [R_ADDR_W-1:0] r_addr;

--- a/submodules/LIB/hardware/modules/reg/iob_reg_r/hardware/src/iob_reg_r.v
+++ b/submodules/LIB/hardware/modules/reg/iob_reg_r/hardware/src/iob_reg_r.v
@@ -12,7 +12,8 @@ module iob_reg_r #(
    output [DATA_W-1:0] data_o
 );
 
-   wire [DATA_W-1:0] data_nxt = rst_i ? RST_VAL : data_i;
+   wire [DATA_W-1:0] data_nxt;
+   assign data_nxt = rst_i ? RST_VAL : data_i;
 
    iob_reg #(
       .DATA_W (DATA_W),

--- a/submodules/LIB/hardware/modules/reg/iob_reg_re/hardware/src/iob_reg_re.v
+++ b/submodules/LIB/hardware/modules/reg/iob_reg_re/hardware/src/iob_reg_re.v
@@ -13,7 +13,8 @@ module iob_reg_re #(
    output [DATA_W-1:0] data_o
 );
 
-   wire [DATA_W-1:0] data = en_i ? data_i : data_o;
+   wire [DATA_W-1:0] data;
+   assign data = en_i ? data_i : data_o;
 
    iob_reg_r #(
       .DATA_W (DATA_W),

--- a/submodules/LIB/hardware/modules/regfile/iob_regfile_2p/hardware/src/iob_regfile_2p.v
+++ b/submodules/LIB/hardware/modules/regfile/iob_regfile_2p/hardware/src/iob_regfile_2p.v
@@ -23,15 +23,18 @@ module iob_regfile_2p #(
    wire [      N-1:0]                                          wen;
 
    //reconstruct write address from waddr_i and wstrb_i
-   wire [WSTRB_W-1:0] wstrb = req_i[WDATA_W+:WSTRB_W];
-   wire [WADDR_W-1:0] waddr = req_i[WSTRB_W+WDATA_W+:WADDR_W];
+   wire [WSTRB_W-1:0] wstrb;
+   wire [WADDR_W-1:0] waddr;
+   assign wstrb = req_i[WDATA_W+:WSTRB_W];
+   assign waddr = req_i[WSTRB_W+WDATA_W+:WADDR_W];
    localparam WADDR_INT_W = (WADDR_W > ($clog2(
        DATA_W / 8
    ) + 1)) ? WADDR_W : ($clog2(
        DATA_W / 8
    ) + 1);
    wire [($clog2(DATA_W/8)+1)-1:0]                                 waddr_incr;
-   wire [         WADDR_INT_W-1:0] waddr_int = waddr + waddr_incr;
+   wire [         WADDR_INT_W-1:0] waddr_int;
+   assign waddr_int = waddr + waddr_incr;
 
    iob_ctls #(
       .W     (DATA_W / 8),
@@ -43,7 +46,8 @@ module iob_regfile_2p #(
    );
 
    //write register file
-   wire [WDATA_W-1:0] wdata_int = req_i[WDATA_W-1:0];
+   wire [WDATA_W-1:0] wdata_int;
+   assign wdata_int = req_i[WDATA_W-1:0];
    genvar row_sel;
    genvar col_sel;
 
@@ -75,7 +79,8 @@ module iob_regfile_2p #(
    //read register file
    generate
       if (RADDR_W > 0) begin : g_read
-         wire [RADDR_W-1:0] raddr = req_i[(WSTRB_W+WDATA_W)+WADDR_W+:RADDR_W];
+         wire [RADDR_W-1:0] raddr;
+         assign raddr = req_i[(WSTRB_W+WDATA_W)+WADDR_W+:RADDR_W];
          assign resp_o = regfile[RDATA_W*raddr+:RDATA_W];
       end else begin : g_read
          assign resp_o = regfile;

--- a/submodules/LIB/hardware/modules/regfile/iob_regfile_at2p/hardware/src/iob_regfile_at2p.v
+++ b/submodules/LIB/hardware/modules/regfile/iob_regfile_at2p/hardware/src/iob_regfile_at2p.v
@@ -43,7 +43,8 @@ module iob_regfile_at2p #(
    endgenerate
 
 
-   wire [DATA_W-1:0] r_data = regfile_in[r_addr_i*DATA_W+:DATA_W];
+   wire [DATA_W-1:0] r_data;
+   assign r_data = regfile_in[r_addr_i*DATA_W+:DATA_W];
 
    //read
    iob_reg #(

--- a/submodules/LIB/hardware/modules/regfile/iob_regfile_sp/hardware/src/iob_regfile_sp.v
+++ b/submodules/LIB/hardware/modules/regfile/iob_regfile_sp/hardware/src/iob_regfile_sp.v
@@ -13,14 +13,16 @@ module iob_regfile_sp #(
    output [DATA_W-1:0] d_o
 );
 
-   wire [DATA_W*(2**ADDR_W)-1:0] data_in = d_i << (addr_i * DATA_W);
+   wire [DATA_W*(2**ADDR_W)-1:0] data_in;
+   assign data_in = d_i << (addr_i * DATA_W);
    wire [DATA_W*(2**ADDR_W)-1:0] data_out;
    assign d_o = data_out >> (addr_i * DATA_W);
 
    genvar i;
    generate
       for (i = 0; i < 2**ADDR_W; i = i + 1) begin: g_regfile        
-         wire reg_en_i = we_i & (addr_i == i);
+         wire reg_en_i;
+         assign reg_en_i = we_i & (addr_i == i);
          iob_reg_re
                #(
                  .DATA_W(DATA_W)


### PR DESCRIPTION
- remove wire declaration and assignment in the same line
- wire declaration and assignment does not work for ASIC
- only updated for asrc modules
- there are other modules still need changes
- list problem instances with: `grep -rn wire | grep =`