### PR TITLE
fix(coverage): update modules to improve coverage

### DIFF
--- a/submodules/LIB/hardware/modules/acc/iob_acc/hardware/src/iob_acc.v
+++ b/submodules/LIB/hardware/modules/acc/iob_acc/hardware/src/iob_acc.v
@@ -2,12 +2,13 @@
 
 module iob_acc #(
    parameter DATA_W  = 21,
+   parameter INCR_W  = DATA_W,
    parameter RST_VAL = {DATA_W{1'b0}}
 ) (
    `include "clk_en_rst_s_port.vs"
    input rst_i,
    input en_i,
-   input  [DATA_W-1:0] incr_i,
+   input  [INCR_W-1:0] incr_i,
    output [DATA_W-1:0] data_o,
    output [DATA_W:0] data_nxt_o
 );

--- a/submodules/LIB/hardware/modules/acc/iob_acc_ld/hardware/src/iob_acc_ld.v
+++ b/submodules/LIB/hardware/modules/acc/iob_acc_ld/hardware/src/iob_acc_ld.v
@@ -2,6 +2,7 @@
 
 module iob_acc_ld #(
    parameter DATA_W  = 21,
+   parameter INCR_W  = DATA_W,
    parameter RST_VAL = {DATA_W{1'b0}}
 ) (
 `include "clk_en_rst_s_port.vs"
@@ -9,7 +10,7 @@ module iob_acc_ld #(
    input               en_i,
    input               ld_i,
    input [DATA_W-1:0]  ld_val_i,
-   input [DATA_W-1:0]  incr_i,
+   input [INCR_W-1:0]  incr_i,
    output [DATA_W-1:0] data_o,
    output [DATA_W:0]   data_nxt_o
    );

--- a/submodules/LIB/hardware/modules/counter/iob_modcnt/hardware/src/iob_modcnt.v
+++ b/submodules/LIB/hardware/modules/counter/iob_modcnt/hardware/src/iob_modcnt.v
@@ -15,10 +15,7 @@ module iob_modcnt #(
 );
 
    wire ld_count;
-   wire [DATA_W-1:0] ld_val;
-
    assign ld_count = (data_o >= mod_i);
-   assign ld_val = {DATA_W{1'b0}};
 
    iob_counter_ld #(
       .DATA_W (DATA_W),
@@ -28,7 +25,7 @@ module iob_modcnt #(
       .rst_i   (rst_i),
       .en_i    (en_i),
       .ld_i    (ld_count),
-      .ld_val_i(ld_val),
+      .ld_val_i({DATA_W{1'b0}}),
       .data_o  (data_o)
    );
 

--- a/submodules/LIB/hardware/modules/counter/iob_modcnt/hardware/src/iob_modcnt.v
+++ b/submodules/LIB/hardware/modules/counter/iob_modcnt/hardware/src/iob_modcnt.v
@@ -17,16 +17,18 @@ module iob_modcnt #(
    wire ld_count;
    assign ld_count = (data_o >= mod_i);
 
-   iob_counter_ld #(
+   wire [DATA_W-1:0] data;
+   assign data = ld_count ? {DATA_W{1'b0}} : data_o + 1'b1;
+
+   iob_reg_re #(
       .DATA_W (DATA_W),
       .RST_VAL(RST_VAL)
-   ) cnt0 (
+   ) reg0 (
       `include "clk_en_rst_s_s_portmap.vs"
-      .rst_i   (rst_i),
-      .en_i    (en_i),
-      .ld_i    (ld_count),
-      .ld_val_i({DATA_W{1'b0}}),
-      .data_o  (data_o)
+      .rst_i (rst_i),
+      .en_i  (en_i),
+      .data_i(data),
+      .data_o(data_o)
    );
 
 endmodule


### PR DESCRIPTION
- update modules to improve coverage:
- accumulators now have `INCR_W` parameter to set increment width,
  different from `DATA_W`
- update modcnt to remove internal `ld_val` always 0. Keep same
  functionality