### PR TITLE
Update py2hwsw to latest version - Support DDR on Smart Zynq SL and Zybo Z7 boards.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,8 +5,8 @@
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/25.05.tar.gz") {} }:
 
 let
-  py2hwsw_commit = "1412882907e6c800506d8763308e9b664c6f5fbe"; # Replace with the desired commit.
-  py2hwsw_sha256 = "VsSw4awW98RpOFwnAhMFoEt5M/CAMlP3Xe2OcXW7P1s="; # Replace with the actual SHA256 hash.
+  py2hwsw_commit = "27b516916982703c565660c3eb48d7ab01450212"; # Replace with the desired commit.
+  py2hwsw_sha256 = "OJ64anFHPJH2n+VpBe5RLaL4SiMo8OO343raB6hSXLY="; # Replace with the actual SHA256 hash.
   # Get local py2hwsw root from `PY2HWSW_ROOT` env variable
   py2hwswRoot = builtins.getEnv "PY2HWSW_ROOT";
 


### PR DESCRIPTION
Related to PR https://github.com/IObundle/py2hwsw/pull/438

New py2hwsw version brings support for external PS7 DDR memory (USE_EXTMEM=1) with the Smart Zynq SL and Zybo Z7 FPGA boards.

To run iob-soc with external memory on the Smart Zynq SL board, use:
```bash
make fpga-run BOARD=iob_smart_zynq_sl USE_INTMEM=0 USE_EXTMEM=1 INIT_MEM=0
```

You may need to set environment variables according to your setup:
```bash
# My local vivado installation path
export PATH=$PATH:/hdd/Xilinx/2025.1/Vivado/bin
# My local vitis installation path
export PATH=$PATH:/hdd/Xilinx/2025.1/Vitis/bin
# My local smart zynq sl serial port:
export SMART_ZYNQ_SL_SERIAL_PORT=/dev/ttyUSB0
```